### PR TITLE
Add preflight playbook

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright Red Hat
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,26 @@
+[defaults]
+log_path = $HOME/ansible/ansible.log
+library = ./library
+module_utils = ./module_utils
+roles_path = ./
+
+forks = 20
+host_key_checking = False
+gathering = smart
+fact_caching = jsonfile
+fact_caching_connection = $HOME/ansible/facts
+fact_caching_timeout = 7200
+nocows = 1
+callback_whitelist = profile_tasks
+stdout_callback = yaml
+force_valid_group_names = ignore
+inject_facts_as_vars = False
+retry_files_enabled = False
+timeout = 60
+
+[ssh_connection]
+control_path = %(directory)s/%%h-%%r-%%p
+ssh_args = -o ControlMaster=auto -o ControlPersist=600s
+pipelining = True
+retries = 10
+

--- a/ceph-defaults/README.md
+++ b/ceph-defaults/README.md
@@ -1,0 +1,3 @@
+# Ansible role: ceph-defaults
+
+Documentation is available at http://docs.ceph.com/cephadm-ansible/.

--- a/ceph-defaults/defaults/main.yml
+++ b/ceph-defaults/defaults/main.yml
@@ -1,0 +1,38 @@
+---
+# Preflight variables
+ceph_origin: community
+ceph_dev_branch: master
+ceph_dev_sha1: latest
+ceph_rhcs_version: 5
+ceph_mirror: https://download.ceph.com
+ceph_stable_key: https://download.ceph.com/keys/release.asc
+ceph_release: pacific
+upgrade_ceph_packages: false
+ceph_pkgs:
+  - chrony
+  - cephadm
+  - podman
+# Bootstrap variables
+cluster: ceph
+mon_group_name: mons
+osd_group_name: osds
+rgw_group_name: rgws
+mds_group_name: mdss
+nfs_group_name: nfss
+rbdmirror_group_name: rbdmirrors
+client_group_name: clients
+iscsi_gw_group_name: iscsigws
+mgr_group_name: mgrs
+rgwloadbalancer_group_name: rgwloadbalancers
+monitoring_group_name: monitoring
+delegate_facts_host: true
+monitor_address: 'x.x.x.x'
+dashboard_enabled: true
+ceph_container_registry: docker.io
+ceph_container_image: ceph/daemon-base
+ceph_container_image_tag: latest-master
+ceph_container_registry_auth: false
+ceph_container_no_proxy: "localhost,127.0.0.1"
+configure_firewall: true
+health_mon_check_retries: 300
+health_mon_check_delay: 1

--- a/ceph-defaults/meta/main.yml
+++ b/ceph-defaults/meta/main.yml
@@ -1,0 +1,17 @@
+---
+galaxy_info:
+  company: Red Hat
+  author: Guillaume Abrioux
+  description: Handles ceph-ansible default vars for all roles
+  license: Apache
+  min_ansible_version: 2.10
+  platforms:
+    - name: Ubuntu
+      versions:
+        - bionic
+    - name: EL
+      versions:
+        - 
+  galaxy_tags:
+    - system
+dependencies: []

--- a/cephadm-ansible.spec.in
+++ b/cephadm-ansible.spec.in
@@ -1,0 +1,42 @@
+%global commit @COMMIT@
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+Name:           cephadm-ansible
+Version:        @VERSION@
+Release:        @RELEASE@%{?dist}
+Summary:        ansible playbooks to be used with cephadm
+License:        ASL 2.0
+URL:            https://github.com/ceph/cephadm-ansible
+Source0:        %{name}-%{version}-%{shortcommit}.tar.gz
+
+BuildArch:      noarch
+
+BuildRequires: ansible >= 2.10
+Requires: ansible >= 2.10
+
+%description
+cephadm-ansible is a collection of Ansible playbooks to simplify workflows that are not covered by cephadm.
+
+%prep
+%autosetup -p1
+
+%build
+
+%install
+mkdir -p %{buildroot}%{_datarootdir}/cephadm-ansible
+
+for f in ansible.cfg *.yml; do
+  cp -a $f %{buildroot}%{_datarootdir}/cephadm-ansible
+done
+
+%check
+# Borrowed from upstream's .travis.yml:
+ansible-playbook -i dummy-ansible-hosts test.yml --syntax-check
+
+%files
+%doc README.rst
+%license LICENSE
+%{_datarootdir}/cephadm-ansible
+
+%changelog
+

--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -1,4 +1,7 @@
 ---
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+#
 # This playbook configures the Ceph repository.
 # It also installs some prerequisites (podman, lvm2, chronyd, cephadm, ...)
 #

--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -1,0 +1,89 @@
+---
+# This playbook configures the Ceph repository.
+# It also installs some prerequisites (podman, lvm2, chronyd, cephadm, ...)
+#
+# Usage:
+#
+# ansible-playbook -i <inventory host file> cephadm-preflight.yml
+#
+# You can limit the execution to a set of hosts by using `--limit` option:
+#
+# ansible-playbook -i <inventory host file> cephadm-preflight.yml --limit <my_osd_group|my_node_name>
+#
+# You can override variables using `--extra-vars` parameter:
+#
+# ansible-playbook -i <inventory host file> cephadm-preflight.yml --extra-vars "ceph_origin=rhcs"
+#
+
+
+- hosts: all
+  become: true
+  gather_facts: true
+  vars:
+    ceph_origin: community
+    ceph_rhcs_version: 5
+    ceph_mirror: https://download.ceph.com
+    ceph_stable_key: https://download.ceph.com/keys/release.asc
+    ceph_release: pacific
+    upgrade_ceph_packages: false
+    ceph_pkgs:
+      - lvm2
+      - chrony
+      - cephadm
+      - podman
+      - python3
+  tasks:
+    - name: rhcs related tasks
+      when: ceph_origin == 'rhcs'
+      block:
+        - name: enable red hat storage tools repository
+          rhsm_repository:
+            name: "rhceph-{{ ceph_rhcs_version }}-tools-for-rhel-8-{{ ansible_facts['architecture'] }}-rpms"
+
+    - name: enable repo from download.ceph.com
+      when: ceph_origin == 'community'
+      block:
+        - name: configure red hat ceph community repository stable key
+          rpm_key:
+            key: "{{ ceph_stable_key }}"
+            state: present
+          register: result
+          until: result is succeeded
+
+        - name: configure red hat ceph stable community repository
+          yum_repository:
+            name: ceph_stable
+            description: Ceph Stable $basearch repo
+            gpgcheck: yes
+            state: present
+            gpgkey: "{{ ceph_stable_key }}"
+            baseurl: "{{ ceph_mirror }}/rpm-{{ ceph_release }}/el{{ ansible_facts['distribution_major_version'] }}/$basearch"
+            file: ceph_stable
+            priority: '2'
+          register: result
+          until: result is succeeded
+
+        - name: configure red hat ceph stable noarch community repository
+          yum_repository:
+            name: ceph_stable_noarch
+            description: Ceph Stable noarch repo
+            gpgcheck: yes
+            state: present
+            gpgkey: "{{ ceph_stable_key }}"
+            baseurl: "{{ ceph_mirror }}/rpm-{{ ceph_release }}/el{{ ansible_facts['distribution_major_version'] }}/noarch"
+            file: ceph_stable
+            priority: '2'
+          register: result
+          until: result is succeeded
+
+    - name: install prerequisites packages
+      package:
+        name: "{{ ceph_pkgs | unique }}"
+        state: "{{ (upgrade_ceph_packages | bool) | ternary('latest', 'present') }}"
+      register: result
+      until: result is succeeded
+
+    - name: ensure chronyd is running
+      service:
+        name: chronyd
+        state: started

--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -19,20 +19,10 @@
 - hosts: all
   become: true
   gather_facts: true
-  vars:
-    ceph_origin: community
-    ceph_rhcs_version: 5
-    ceph_mirror: https://download.ceph.com
-    ceph_stable_key: https://download.ceph.com/keys/release.asc
-    ceph_release: pacific
-    upgrade_ceph_packages: false
-    ceph_pkgs:
-      - lvm2
-      - chrony
-      - cephadm
-      - podman
-      - python3
   tasks:
+    - import_role:
+        name: ceph-defaults
+
     - name: rhcs related tasks
       when: ceph_origin == 'rhcs'
       block:

--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -66,6 +66,33 @@
           register: result
           until: result is succeeded
 
+    - name: enable repo from shaman - dev
+      when: ceph_origin == 'shaman'
+      block:
+        - name: fetch ceph red hat development repository
+          uri:
+            url: "https://shaman.ceph.com/api/repos/ceph/{{ ceph_dev_branch }}/{{ ceph_dev_sha1 }}/centos/{{ ansible_facts['distribution_major_version'] }}/repo?arch={{ ansible_facts['architecture'] }}"
+            return_content: yes
+          register: ceph_dev_yum_repo
+
+        - name: configure ceph red hat development repository
+          copy:
+            content: "{{ ceph_dev_yum_repo.content }}"
+            dest: /etc/yum.repos.d/ceph-dev.repo
+            owner: root
+            group: root
+            backup: yes
+
+        - name: remove ceph_stable repositories
+          yum_repository:
+            name: '{{ item }}'
+            file: ceph_stable
+            state: absent
+          with_items:
+            - ceph_stable
+            - ceph_stable_noarch
+
+
     - name: install prerequisites packages
       package:
         name: "{{ ceph_pkgs | unique }}"

--- a/tests/functional/Vagrantfile
+++ b/tests/functional/Vagrantfile
@@ -1,0 +1,145 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+NMONS = 3
+NOSDS = 3
+NMDSS = 0
+NRGWS = 0
+NNFSS = 0
+MGRS  = 0
+LABEL_PREFIX = ''
+MEMORY = 1024
+
+PUBLIC_SUBNET   = '192.168.9'
+CLUSTER_SUBNET  = '192.168.10'
+BOX             = ENV['CEPH_ANSIBLE_VAGRANT_BOX']
+
+ansible_provision = proc do |ansible|
+    ansible.playbook = '../cephadm-preflight.yml'
+    ansible.groups = {
+      'mons'             => (0..NMONS - 1).map { |j| "#{LABEL_PREFIX}mon#{j}" },
+      'osds'             => (0..NOSDS - 1).map { |j| "#{LABEL_PREFIX}osd#{j}" },
+      'mdss'             => (0..NMDSS - 1).map { |j| "#{LABEL_PREFIX}mds#{j}" },
+      'rgws'             => (0..NRGWS - 1).map { |j| "#{LABEL_PREFIX}rgw#{j}" },
+      'nfss'             => (0..NNFSS - 1).map { |j| "#{LABEL_PREFIX}nfs#{j}" },
+      'mgrs'             => (0..MGRS - 1).map { |j| "#{LABEL_PREFIX}mgr#{j}" },
+    }
+    ansible.limit = 'all'
+    ansible.verbose = '-vv'
+    ansible.extra_vars = {
+      ceph_origin: "community",
+    }
+end
+
+Vagrant.configure('2') do |config|
+  config.vm.box =  BOX || 'centos/8'
+  config.ssh.insert_key = false # workaround for https://github.com/mitchellh/vagrant/issues/5048
+#  config.ssh.private_key_path = settings['ssh_private_key_path']
+  config.ssh.username = 'vagrant'
+  config.vm.provider :libvirt do |lv|
+    lv.cpu_mode = 'host-passthrough'
+    lv.volume_cache = 'unsafe'
+    lv.graphics_type = 'none'
+    lv.cpus = 4
+  end
+
+$last_ip_pub_digit   = 9
+$last_ip_cluster_digit = 9
+
+config.vm.provider :libvirt do |v,override|
+  override.vm.synced_folder '.', '/vagrant', disabled: true
+end
+
+
+  (0..NMONS - 1).each do |i|
+    config.vm.define "#{LABEL_PREFIX}mon#{i}" do |mon|
+      mon.vm.hostname = "#{LABEL_PREFIX}mon#{i}"
+      mon.vm.network :private_network,
+        ip: "#{PUBLIC_SUBNET}.#{$last_ip_pub_digit+=1}"
+
+      # Libvirt
+      mon.vm.provider :libvirt do |lv|
+        lv.memory = MEMORY
+        lv.random_hostname = true
+      end
+    end
+  end
+
+  (0..MGRS - 1).each do |i|
+    config.vm.define "#{LABEL_PREFIX}mgr#{i}" do |mgr|
+      mgr.vm.hostname = "#{LABEL_PREFIX}mgr#{i}"
+      mgr.vm.network :private_network,
+        ip: "#{PUBLIC_SUBNET}.#{$last_ip_pub_digit+=1}"
+
+      # Libvirt
+      mgr.vm.provider :libvirt do |lv|
+        lv.memory = MEMORY
+        lv.random_hostname = true
+      end
+    end
+  end
+
+  (0..NRGWS - 1).each do |i|
+    config.vm.define "#{LABEL_PREFIX}rgw#{i}" do |rgw|
+      rgw.vm.hostname = "#{LABEL_PREFIX}rgw#{i}"
+      rgw.vm.network :private_network,
+        ip: "#{PUBLIC_SUBNET}.#{$last_ip_pub_digit+=1}"
+
+      # Libvirt
+      rgw.vm.provider :libvirt do |lv|
+        lv.memory = MEMORY
+        lv.random_hostname = true
+      end
+    end
+  end
+
+  (0..NNFSS - 1).each do |i|
+    config.vm.define "#{LABEL_PREFIX}nfs#{i}" do |nfs|
+      nfs.vm.hostname = "#{LABEL_PREFIX}nfs#{i}"
+      nfs.vm.network :private_network,
+        ip: "#{PUBLIC_SUBNET}.#{$last_ip_pub_digit+=1}"
+
+      # Libvirt
+      nfs.vm.provider :libvirt do |lv|
+        lv.memory = MEMORY
+        lv.random_hostname = true
+      end
+    end
+  end
+
+  (0..NMDSS - 1).each do |i|
+    config.vm.define "#{LABEL_PREFIX}mds#{i}" do |mds|
+      mds.vm.hostname = "#{LABEL_PREFIX}mds#{i}"
+      mds.vm.network :private_network,
+        ip: "#{PUBLIC_SUBNET}.#{$last_ip_pub_digit+=1}"
+      # Libvirt
+      mds.vm.provider :libvirt do |lv|
+        lv.memory = MEMORY
+        lv.random_hostname = true
+      end
+    end
+  end
+
+  (0..NOSDS - 1).each do |i|
+    config.vm.define "#{LABEL_PREFIX}osd#{i}" do |osd|
+      osd.vm.hostname = "#{LABEL_PREFIX}osd#{i}"
+      osd.vm.network :private_network,
+        ip: "#{PUBLIC_SUBNET}.#{$last_ip_pub_digit+=1}"
+      osd.vm.network :private_network,
+        ip: "#{CLUSTER_SUBNET}.#{$last_ip_cluster_digit+=1}"
+
+      # Libvirt
+      driverletters = ('a'..'z').to_a
+      osd.vm.provider :libvirt do |lv|
+        # always make /dev/sd{a/b/c} so that CI can ensure that
+        # virtualbox and libvirt will have the same devices to use for OSDs
+        (0..2).each do |d|
+          lv.storage :file, :device => "hd#{driverletters[d]}", :size => '50G', :bus => "ide"
+        end
+        lv.memory = MEMORY
+        lv.random_hostname = true
+      end
+      osd.vm.provision 'ansible', &ansible_provision if i == (NOSDS - 1)
+    end
+  end
+end

--- a/tests/functional/hosts
+++ b/tests/functional/hosts
@@ -1,0 +1,9 @@
+[mons]
+mon0
+mon1
+mon2
+
+[osds]
+osd0
+osd1
+osd2

--- a/tests/functional/tests/test_preflight.py
+++ b/tests/functional/tests/test_preflight.py
@@ -1,0 +1,17 @@
+class TestPreflight(object):
+    def test_cephadm_package_is_installed(self, host):
+        assert host.package("cephadm").is_installed
+
+    def test_lvm2_package_is_installed(self, host):
+        assert host.package("lvm2").is_installed
+
+    def test_chrony_package_is_installed(self, host):
+        assert host.package("chrony").is_installed
+
+    def test_podman_package_is_installed(self, host):
+        assert host.package("podman").is_installed
+
+    def test_chronyd_is_active(self, host):
+        svc = host.service("chronyd")
+        assert svc.is_enabled
+        assert svc.is_running

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,5 @@
+testinfra>=3,<4
+pytest-xdist==1.28.0
+pytest>=4.6,<5.0
+ansible>=2.10,<2.11,!=2.9.10
+Jinja2>=2.10

--- a/tests/scripts/generate_ssh_config.sh
+++ b/tests/scripts/generate_ssh_config.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Generate a custom ssh config from Vagrant so that it can then be used by
+# ansible.cfg
+
+path=$1
+
+if [ $# -eq 0 ]
+  then
+    echo "A path to the scenario is required as an argument and it wasn't provided"
+    exit 1
+fi
+
+cd "$path"
+vagrant ssh-config > vagrant_ssh_config
+

--- a/tests/scripts/vagrant_up.sh
+++ b/tests/scripts/vagrant_up.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+retries=0
+until [ $retries -ge 5 ]
+do
+  echo "Attempting to start VMs. Attempts: $retries"
+  timeout 10m time vagrant up "$@" && break
+  retries=$[$retries+1]
+  sleep 5
+done
+
+sleep 10

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,35 @@
+[tox]
+skipsdist = True
+
+[testenv]
+whitelist_externals =
+    vagrant
+    bash
+    pip
+passenv=*
+sitepackages=True
+setenv=
+  ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
+  ANSIBLE_CONFIG = {toxinidir}/ansible.cfg
+  ANSIBLE_CALLBACK_WHITELIST = profile_tasks
+  ANSIBLE_KEEP_REMOTE_FILES = 1
+  ANSIBLE_CACHE_PLUGIN = memory
+  ANSIBLE_GATHERING = implicit
+  # only available for ansible >= 2.5
+  ANSIBLE_STDOUT_CALLBACK = yaml
+  # Set the vagrant box image to use
+  CEPH_ANSIBLE_VAGRANT_BOX = centos/8
+
+deps= -r{toxinidir}/tests/requirements.txt
+changedir= {toxinidir}/tests/functional
+
+commands=
+  bash {toxinidir}/tests/scripts/vagrant_up.sh --no-provision {posargs:--provider=virtualbox}
+  bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
+
+  # Install prerequisites
+  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/cephadm-preflight.yml
+
+  py.test -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts --ssh-config={changedir}/vagrant_ssh_config {changedir}/tests/
+
+  vagrant destroy -f

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ commands=
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 
   # Install prerequisites
-  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/cephadm-preflight.yml
+  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/cephadm-preflight.yml --extra-vars "ceph_origin=shaman"
 
   py.test -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts --ssh-config={changedir}/vagrant_ssh_config {changedir}/tests/
 


### PR DESCRIPTION
Add the `cephadm-preflight.yml` playbook.

This playbook is intended for installing prerequisites such as NTP (make sure it's installed and running), installing podman, lvm2, and cephadm so everything needed in order to bootstrap a Ceph cluster is available.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1958675