### PR TITLE
cephadm-preflight: handle client nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,25 @@ You can override variables using `--extra-vars` parameter:
 ansible-playbook -i <inventory host file> cephadm-preflight.yml --extra-vars "ceph_origin=rhcs"
 ```
 
+If you plan to deploy client nodes, you must define a group called "clients" in your inventory:
+
+eg:
+
+```
+$ cat hosts
+node1
+node2
+node3
+
+[clients]
+client1
+client2
+client3
+node123
+```
+
+Then you can run the playbook as shown above.
+
 # Purge
 
 This playbook purges a Ceph cluster managed with cephadm

--- a/ceph-defaults/defaults/main.yml
+++ b/ceph-defaults/defaults/main.yml
@@ -12,6 +12,7 @@ ceph_pkgs:
   - chrony
   - cephadm
   - podman
+  - ceph-common
 # Bootstrap variables
 cluster: ceph
 mon_group_name: mons

--- a/cephadm-ansible.spec.in
+++ b/cephadm-ansible.spec.in
@@ -11,8 +11,8 @@ Source0:        %{name}-%{version}-%{shortcommit}.tar.gz
 
 BuildArch:      noarch
 
-BuildRequires: ansible >= 2.10
-Requires: ansible >= 2.10
+BuildRequires: ansible >= 2.9
+Requires: ansible >= 2.9
 
 %description
 cephadm-ansible is a collection of Ansible playbooks to simplify workflows that are not covered by cephadm.

--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -120,3 +120,4 @@
       service:
         name: chronyd
         state: started
+        enabled: yes

--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -17,7 +17,20 @@
 #
 # ansible-playbook -i <inventory host file> cephadm-preflight.yml --extra-vars "ceph_origin=rhcs"
 #
-
+# If you plan to deploy 'client' nodes, you must add a group called 'clients' in your inventory:
+#
+# $ cat hosts
+# mynode1
+# mynode2
+# mynode3
+#
+# [clients]
+# client1
+# client2
+# client3
+#
+# Then, you can run the the same way as shown above. The playbook will automatically install
+# chronyd and ceph-common on those nodes.
 
 - hosts: all
   become: true
@@ -98,7 +111,7 @@
 
     - name: install prerequisites packages
       package:
-        name: "{{ ceph_pkgs | unique }}"
+        name: "{{ ['chrony', 'ceph-common'] if group_names == ['clients'] else ceph_pkgs | unique }}"
         state: "{{ (upgrade_ceph_packages | bool) | ternary('latest', 'present') }}"
       register: result
       until: result is succeeded

--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -108,6 +108,14 @@
             - ceph_stable
             - ceph_stable_noarch
 
+    - name: install epel-release
+      package:
+        name: epel-release
+        state: present
+      register: result
+      until: result is succeeded
+      when: ansible_facts['distribution'] == 'CentOS'
+
 
     - name: install prerequisites packages
       package:

--- a/cephadm-purge-cluster.yml
+++ b/cephadm-purge-cluster.yml
@@ -54,3 +54,4 @@
   tasks:
     - name: purge ceph cluster
       command: "cephadm rm-cluster --force --zap-osds --fsid {{ fsid }}"
+      when: group_names != ['clients']

--- a/tests/functional/Vagrantfile
+++ b/tests/functional/Vagrantfile
@@ -7,6 +7,7 @@ NMDSS = 0
 NRGWS = 0
 NNFSS = 0
 MGRS  = 0
+NCLIENTS = 2
 LABEL_PREFIX = ''
 MEMORY = 1024
 
@@ -22,6 +23,7 @@ ansible_provision = proc do |ansible|
       'mdss'             => (0..NMDSS - 1).map { |j| "#{LABEL_PREFIX}mds#{j}" },
       'rgws'             => (0..NRGWS - 1).map { |j| "#{LABEL_PREFIX}rgw#{j}" },
       'nfss'             => (0..NNFSS - 1).map { |j| "#{LABEL_PREFIX}nfs#{j}" },
+      'clients'          => (0..NCLIENTS - 1).map { |j| "#{LABEL_PREFIX}client#{j}" },
       'mgrs'             => (0..MGRS - 1).map { |j| "#{LABEL_PREFIX}mgr#{j}" },
     }
     ansible.limit = 'all'
@@ -54,6 +56,20 @@ end
   (0..NMONS - 1).each do |i|
     config.vm.define "#{LABEL_PREFIX}mon#{i}" do |mon|
       mon.vm.hostname = "#{LABEL_PREFIX}mon#{i}"
+      mon.vm.network :private_network,
+        ip: "#{PUBLIC_SUBNET}.#{$last_ip_pub_digit+=1}"
+
+      # Libvirt
+      mon.vm.provider :libvirt do |lv|
+        lv.memory = MEMORY
+        lv.random_hostname = true
+      end
+    end
+  end
+
+  (0..NCLIENTS - 1).each do |i|
+    config.vm.define "#{LABEL_PREFIX}client#{i}" do |mon|
+      mon.vm.hostname = "#{LABEL_PREFIX}client#{i}"
       mon.vm.network :private_network,
         ip: "#{PUBLIC_SUBNET}.#{$last_ip_pub_digit+=1}"
 

--- a/tests/functional/Vagrantfile
+++ b/tests/functional/Vagrantfile
@@ -1,16 +1,12 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-NMONS = 3
-NOSDS = 3
-NMDSS = 0
-NRGWS = 0
-NNFSS = 0
-MGRS  = 0
-NCLIENTS = 2
-LABEL_PREFIX = ''
-MEMORY = 1024
+# took from ceph-ansible project
 
+NNODE           = 6
+NCLIENTS        = 2
+LABEL_PREFIX    = 'ceph-'
+MEMORY          = 1024
 PUBLIC_SUBNET   = '192.168.9'
 CLUSTER_SUBNET  = '192.168.10'
 BOX             = ENV['CEPH_ANSIBLE_VAGRANT_BOX']
@@ -18,13 +14,8 @@ BOX             = ENV['CEPH_ANSIBLE_VAGRANT_BOX']
 ansible_provision = proc do |ansible|
     ansible.playbook = '../cephadm-preflight.yml'
     ansible.groups = {
-      'mons'             => (0..NMONS - 1).map { |j| "#{LABEL_PREFIX}mon#{j}" },
-      'osds'             => (0..NOSDS - 1).map { |j| "#{LABEL_PREFIX}osd#{j}" },
-      'mdss'             => (0..NMDSS - 1).map { |j| "#{LABEL_PREFIX}mds#{j}" },
-      'rgws'             => (0..NRGWS - 1).map { |j| "#{LABEL_PREFIX}rgw#{j}" },
-      'nfss'             => (0..NNFSS - 1).map { |j| "#{LABEL_PREFIX}nfs#{j}" },
-      'clients'          => (0..NCLIENTS - 1).map { |j| "#{LABEL_PREFIX}client#{j}" },
-      'mgrs'             => (0..MGRS - 1).map { |j| "#{LABEL_PREFIX}mgr#{j}" },
+      'ceph_cluster'             => (0..NNODE - 1).map { |j| "#{LABEL_PREFIX}node#{j}" },
+      'clients'          => (0..NCLIENTS - 1).map { |j| "client#{j}" },
     }
     ansible.limit = 'all'
     ansible.verbose = '-vv'
@@ -53,100 +44,31 @@ config.vm.provider :libvirt do |v,override|
 end
 
 
-  (0..NMONS - 1).each do |i|
-    config.vm.define "#{LABEL_PREFIX}mon#{i}" do |mon|
-      mon.vm.hostname = "#{LABEL_PREFIX}mon#{i}"
-      mon.vm.network :private_network,
-        ip: "#{PUBLIC_SUBNET}.#{$last_ip_pub_digit+=1}"
-
-      # Libvirt
-      mon.vm.provider :libvirt do |lv|
-        lv.memory = MEMORY
-        lv.random_hostname = true
-      end
-    end
-  end
-
   (0..NCLIENTS - 1).each do |i|
-    config.vm.define "#{LABEL_PREFIX}client#{i}" do |mon|
-      mon.vm.hostname = "#{LABEL_PREFIX}client#{i}"
-      mon.vm.network :private_network,
+    config.vm.define "client#{i}" do |client|
+      client.vm.hostname = "client#{i}"
+      client.vm.network :private_network,
         ip: "#{PUBLIC_SUBNET}.#{$last_ip_pub_digit+=1}"
 
       # Libvirt
-      mon.vm.provider :libvirt do |lv|
+      client.vm.provider :libvirt do |lv|
         lv.memory = MEMORY
         lv.random_hostname = true
       end
     end
   end
 
-  (0..MGRS - 1).each do |i|
-    config.vm.define "#{LABEL_PREFIX}mgr#{i}" do |mgr|
-      mgr.vm.hostname = "#{LABEL_PREFIX}mgr#{i}"
-      mgr.vm.network :private_network,
+  (0..NNODE - 1).each do |i|
+    config.vm.define "#{LABEL_PREFIX}node#{i}" do |node|
+      node.vm.hostname = "#{LABEL_PREFIX}node#{i}"
+      node.vm.network :private_network,
         ip: "#{PUBLIC_SUBNET}.#{$last_ip_pub_digit+=1}"
-
-      # Libvirt
-      mgr.vm.provider :libvirt do |lv|
-        lv.memory = MEMORY
-        lv.random_hostname = true
-      end
-    end
-  end
-
-  (0..NRGWS - 1).each do |i|
-    config.vm.define "#{LABEL_PREFIX}rgw#{i}" do |rgw|
-      rgw.vm.hostname = "#{LABEL_PREFIX}rgw#{i}"
-      rgw.vm.network :private_network,
-        ip: "#{PUBLIC_SUBNET}.#{$last_ip_pub_digit+=1}"
-
-      # Libvirt
-      rgw.vm.provider :libvirt do |lv|
-        lv.memory = MEMORY
-        lv.random_hostname = true
-      end
-    end
-  end
-
-  (0..NNFSS - 1).each do |i|
-    config.vm.define "#{LABEL_PREFIX}nfs#{i}" do |nfs|
-      nfs.vm.hostname = "#{LABEL_PREFIX}nfs#{i}"
-      nfs.vm.network :private_network,
-        ip: "#{PUBLIC_SUBNET}.#{$last_ip_pub_digit+=1}"
-
-      # Libvirt
-      nfs.vm.provider :libvirt do |lv|
-        lv.memory = MEMORY
-        lv.random_hostname = true
-      end
-    end
-  end
-
-  (0..NMDSS - 1).each do |i|
-    config.vm.define "#{LABEL_PREFIX}mds#{i}" do |mds|
-      mds.vm.hostname = "#{LABEL_PREFIX}mds#{i}"
-      mds.vm.network :private_network,
-        ip: "#{PUBLIC_SUBNET}.#{$last_ip_pub_digit+=1}"
-      # Libvirt
-      mds.vm.provider :libvirt do |lv|
-        lv.memory = MEMORY
-        lv.random_hostname = true
-      end
-    end
-  end
-
-  (0..NOSDS - 1).each do |i|
-    config.vm.define "#{LABEL_PREFIX}osd#{i}" do |osd|
-      osd.vm.hostname = "#{LABEL_PREFIX}osd#{i}"
-      osd.vm.network :private_network,
-        ip: "#{PUBLIC_SUBNET}.#{$last_ip_pub_digit+=1}"
-      osd.vm.network :private_network,
+      node.vm.network :private_network,
         ip: "#{CLUSTER_SUBNET}.#{$last_ip_cluster_digit+=1}"
 
       # Libvirt
       driverletters = ('a'..'z').to_a
-      osd.vm.provider :libvirt do |lv|
+      node.vm.provider :libvirt do |lv|
         # always make /dev/sd{a/b/c} so that CI can ensure that
         # virtualbox and libvirt will have the same devices to use for OSDs
         (0..2).each do |d|
@@ -155,7 +77,7 @@ end
         lv.memory = MEMORY
         lv.random_hostname = true
       end
-      osd.vm.provision 'ansible', &ansible_provision if i == (NOSDS - 1)
+      node.vm.provision 'ansible', &ansible_provision if i == (NNODE - 1)
     end
   end
 end

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+@pytest.fixture()
+def node(host, request):
+    ansible_vars = host.ansible.get_variables()
+
+    if request.node.get_closest_marker("no_client") and ansible_vars['group_names'] == ['clients']:
+        pytest.skip("Not a valid test for client nodes")
+

--- a/tests/functional/deploy-cluster.yml
+++ b/tests/functional/deploy-cluster.yml
@@ -152,7 +152,7 @@
         CEPHADM_IMAGE: '{{ ceph_container_registry }}/{{ ceph_container_image }}:{{ ceph_container_image_tag }}'
 
     - name: manage nodes with cephadm
-      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch host add {{ ansible_facts['hostname'] }} {{ ansible_facts['default_ipv4']['address'] }} {{ group_names | join(' ') }} {{ '_admin' if inventory_hostname == 'mon0' else '' }}"
+      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch host add {{ ansible_facts['hostname'] }} {{ ansible_facts['default_ipv4']['address'] }} {{ group_names | join(' ') }} {{ '_admin' if inventory_hostname == 'ceph-node0' else '' }}"
       changed_when: false
       delegate_to: '{{ groups[mon_group_name][0] }}'
       environment:

--- a/tests/functional/hosts
+++ b/tests/functional/hosts
@@ -13,3 +13,7 @@ osd2
 
 [admin]
 mon0
+
+[clients]
+client0
+client1

--- a/tests/functional/hosts
+++ b/tests/functional/hosts
@@ -1,19 +1,28 @@
-[mons]
-mon0
-mon1
-mon2
-
-[mgrs]
-mon0
-
-[osds]
-osd0
-osd1
-osd2
+[ceph_cluster]
+ceph-node0
+ceph-node1
+ceph-node2
+ceph-node3
+ceph-node4
+ceph-node5
 
 [admin]
-mon0
+ceph-node0
 
 [clients]
 client0
 client1
+
+# deploy-cluster.yml groups related
+[mons]
+ceph-node0
+ceph-node1
+ceph-node2
+
+[mgrs]
+ceph-node0
+
+[osds]
+ceph-node3
+ceph-node4
+ceph-node5

--- a/tests/functional/tests/test_preflight.py
+++ b/tests/functional/tests/test_preflight.py
@@ -1,17 +1,25 @@
+import pytest
+
 class TestPreflight(object):
-    def test_cephadm_package_is_installed(self, host):
+    @pytest.mark.no_client
+    def test_cephadm_package_is_installed(self, node, host):
         assert host.package("cephadm").is_installed
 
-    def test_lvm2_package_is_installed(self, host):
+    @pytest.mark.no_client
+    def test_lvm2_package_is_installed(self, node, host):
         assert host.package("lvm2").is_installed
 
-    def test_chrony_package_is_installed(self, host):
+    def test_chrony_package_is_installed(self, node, host):
         assert host.package("chrony").is_installed
 
-    def test_podman_package_is_installed(self, host):
+    @pytest.mark.no_client
+    def test_podman_package_is_installed(self, node, host):
         assert host.package("podman").is_installed
 
-    def test_chronyd_is_active(self, host):
+    def test_chronyd_is_active(self, node, host):
         svc = host.service("chronyd")
         assert svc.is_enabled
         assert svc.is_running
+
+    def test_cephcommon_package_is_installed(self, node, host):
+        assert host.package("ceph-common").is_installed

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
 testinfra>=3,<4
 pytest-xdist==1.28.0
 pytest>=4.6,<5.0
-ansible>=2.10,<2.11,!=2.9.10
+ansible>=2.9,<2.10,!=2.9.10
 Jinja2>=2.10

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands=
   # Deploy a Ceph cluster
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/deploy-cluster.yml --extra-vars "\
       dashboard_enabled=false \
-      monitor_address=192.168.9.10 \
+      monitor_address=192.168.9.12 \
       ceph_container_registry_auth=true \
       ceph_container_registry=quay.ceph.io \
       ceph_container_image=ceph-ci/daemon-base \


### PR DESCRIPTION
This adds the possibility to setup repositories on nodes intended to be
used as 'clients'.
Basically, it requires you to define a new group called "clients" in
your existing inventory.

    eg:

     $ cat hosts
     mynode1
     mynode2
     mynode3

     [clients]
     client1
     client2
     client3

Then, you can run the playbook as documented:

$ ansible-playbook -i hosts cephadm-preflight.yml

This will install the packages 'chronyd' and 'ceph-common' on those
nodes.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>