### PR TITLE
cephadm-ansible.spec.in: fix README

### DIFF
--- a/cephadm-ansible.spec.in
+++ b/cephadm-ansible.spec.in
@@ -34,7 +34,7 @@ done
 ansible-playbook -i dummy-ansible-hosts test.yml --syntax-check
 
 %files
-%doc README.rst
+%doc README.md
 %license LICENSE
 %{_datarootdir}/cephadm-ansible
 


### PR DESCRIPTION
The README file is markdown, not restructured text.