### PR TITLE
cephadm-purge: workaround --zap-osds param issue

### DIFF
--- a/cephadm-purge-cluster.yml
+++ b/cephadm-purge-cluster.yml
@@ -52,6 +52,9 @@
   become: true
   gather_facts: false
   tasks:
+    - import_role:
+        name: ceph-defaults
+
     - name: purge ceph cluster
-      command: "cephadm rm-cluster --force --zap-osds --fsid {{ fsid }}"
+      command: "cephadm rm-cluster --force {{ '--zap-osds' if ceph_origin == 'rhcs' or ceph_origin == 'shaman' else '' }} --fsid {{ fsid }}"
       when: group_names != ['clients']


### PR DESCRIPTION
`--zap-osds` isn't available yet when using `ceph_origin: community`
As a workaround, until 16.2.5 is out let's use this logic to make the
playbook not fail.

Fixes: #14

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>