### PR TITLE
tests: use cephadm registry builtin command

### DIFF
--- a/tests/functional/deploy-cluster.yml
+++ b/tests/functional/deploy-cluster.yml
@@ -46,21 +46,18 @@
       set_fact:
         is_atomic: "{{ stat_ostree.stat.exists }}"
 
+    - name: set_fact cephadm_cmd
+      set_fact:
+        cephadm_cmd: "cephadm {{ '--docker' if container_binary == 'docker' else '' }}"
+
     - name: container registry authentication
-      command: '{{ container_binary }} login -u {{ ceph_container_registry_username }} --password-stdin {{ ceph_container_registry }}'
-      args:
-        stdin: '{{ ceph_container_registry_password }}'
-        stdin_add_newline: no
+      command: "{{ cephadm_cmd }} registry-login --registry-url {{ ceph_container_registry }} --registry-username {{ ceph_container_registry_username }} --registry-password {{ ceph_container_registry_password }}"
       changed_when: false
       environment:
         HTTP_PROXY: "{{ ceph_container_http_proxy | default('') }}"
         HTTPS_PROXY: "{{ ceph_container_https_proxy | default('') }}"
         NO_PROXY: "{{ ceph_container_no_proxy }}"
       when: ceph_container_registry_auth | default(False) | bool
-
-    - name: set_fact cephadm_cmd
-      set_fact:
-        cephadm_cmd: "cephadm {{ '--docker' if container_binary == 'docker' else '' }}"
 
 - name: bootstrap the cluster
   hosts: "{{ mon_group_name }}[0]"


### PR DESCRIPTION
Instead of doing the registry login task manually with podman/docker, we
can use the registry-login cephadm command for that.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>