### PR TITLE
purge: explicitly provide fsid for cephadm shell

### DIFF
--- a/cephadm-purge-cluster.yml
+++ b/cephadm-purge-cluster.yml
@@ -46,7 +46,7 @@
       when: not admin_keyring_stat.stat.exists | bool
 
     - name: pause cephadm
-      command: "cephadm shell -- ceph orch pause"
+      command: "cephadm shell --fsid {{ fsid }} -- ceph orch pause"
 
 - hosts: all
   become: true


### PR DESCRIPTION
The fsid value is already mandatory for running the purge playbook and
we provide the value to the rm-cluster command.
Let's do the same for the cephadm shell command.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1980012

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>