### PR TITLE
tox: remove duplicate line

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,6 @@ commands=
       ceph_container_registry=quay.io \
       ceph_container_image=ceph/ceph \
       ceph_container_image_tag=v16 \
-      ceph_container_registry_auth=true \
       ceph_container_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_container_registry_password={env:DOCKER_HUB_PASSWORD} \
       node_exporter_container_image=quay.ceph.io/prometheus/node-exporter:v0.17.0 \


### PR DESCRIPTION
670d22a introduced a duplicate line for the registry authentication.
Let's remove it.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>