### PR TITLE
pacific: tox: update monitoring container images

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -41,10 +41,10 @@ commands=
       ceph_container_image_tag=v16 \
       ceph_container_registry_username={env:DOCKER_HUB_USERNAME} \
       ceph_container_registry_password={env:DOCKER_HUB_PASSWORD} \
-      node_exporter_container_image=quay.ceph.io/prometheus/node-exporter:v0.17.0 \
-      prometheus_container_image=quay.ceph.io/prometheus/prometheus:v2.7.2 \
-      alertmanager_container_image=quay.ceph.io/prometheus/alertmanager:v0.16.2 \
-      grafana_container_image=quay.ceph.io/app-sre/grafana:6.7.4 \
+      node_exporter_container_image=quay.io/prometheus/node-exporter:v0.18.1 \
+      prometheus_container_image=quay.io/prometheus/prometheus:v2.18.1 \
+      alertmanager_container_image=quay.io/prometheus/alertmanager:v0.20.0 \
+      grafana_container_image=quay.io/ceph/ceph-grafana:6.7.4 \
       fsid=4217f198-b8b7-11eb-941d-5254004b7a69 \
 
   "


### PR DESCRIPTION
This updates the monitoring container images by
- using the quay.io registry
- updating the tags to match what cephadm uses
- using the dedicated ceph grafana image

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>
(cherry picked from commit dc7ce43d2ae985bcadd7130bd1b009e678e17a4f)