### PR TITLE
Fix undefined 'fsid' error in cephadm-purge-cluster.yml

### DIFF
--- a/cephadm-ansible.spec.in
+++ b/cephadm-ansible.spec.in
@@ -31,7 +31,7 @@ done
 
 %check
 ansible-playbook -i tests/functional/hosts cephadm-preflight.yml --syntax-check
-ansible-playbook -i tests/functional/hosts cephadm-purge-cluster.yml --syntax-check
+ansible-playbook -i tests/functional/hosts cephadm-purge-cluster.yml -e fsid=%(uuidgen) --syntax-check
 
 %files
 %doc README.md


### PR DESCRIPTION
We need to set a fsid when %check tests cephadm-purge-cluster.yml, otherwise the RPM build will fail.