### PR TITLE
cephadm-purge-cluster: removes packages

### DIFF
--- a/cephadm-purge-cluster.yml
+++ b/cephadm-purge-cluster.yml
@@ -138,3 +138,20 @@
     - name: purge ceph daemons
       command: "cephadm rm-cluster --force {{ '--zap-osds' if ceph_origin == 'rhcs' or ceph_origin == 'shaman' else '' }} --fsid {{ fsid }}"
       when: group_names != [client_group]
+
+
+- name: remove ceph packages
+  hosts: all
+  become: true
+  gather_facts: false
+  any_errors_fatal: true
+  tasks:
+    - import_role:
+        name: ceph-defaults
+
+    - name: remove ceph packages
+      package:
+        name: "{{ 'ceph-common' if group_names == [client_group] else ceph_pkgs | unique }}"
+        state: absent
+      register: result
+      until: result is succeeded


### PR DESCRIPTION
This commit adds a play in the cephadm-purge-cluster.yml playbook in
order to remove the ceph packages.

Fixes: #26

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>