### PR TITLE
clients:Fix issue when ceph.conf is supplied

### DIFF
--- a/cephadm-clients.yml
+++ b/cephadm-clients.yml
@@ -166,7 +166,7 @@
         backup: yes
       loop:
         - { content: "{{ hostvars[groups['admin'][0]]['client_keyring']['content'] | b64decode }}", dest: '/etc/ceph/ceph.keyring', copy_file: True }
-        - { content: "{{ hostvars[groups['admin'][0]]['minimal_ceph_config']['stdout'] }}", dest: '/etc/ceph/ceph.conf', copy_file: "{{ conf is undefined }}" }
+        - { content: "{{ hostvars[groups['admin'][0]]['minimal_ceph_config']['stdout'] | default('') }}", dest: '/etc/ceph/ceph.conf', copy_file: "{{ conf is undefined }}" }
         - { content: "{{ hostvars[groups['admin'][0]]['ceph_config']['content'] | default('') | b64decode }}", dest: '/etc/ceph/ceph.conf', copy_file: "{{ hostvars[groups['admin'][0]]['ceph_config']['skipped'] is undefined }}" }
       when: item.copy_file | bool
       no_log: true


### PR DESCRIPTION
When a ceph.conf is provided the minimal_conf variable is not
populated which trips up the "copy configuration and keyring.."
step. This patch uses a default, so if the variable is not set, the
syntax is still valid and the line skipped as intended

Closes: #33

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>