### PR TITLE
common: support setting client_group in all playbooks

### DIFF
--- a/ceph-defaults/defaults/main.yml
+++ b/ceph-defaults/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-# Preflight variables
 ceph_origin: community
 ceph_dev_branch: master
 ceph_dev_sha1: latest
@@ -17,27 +16,3 @@ ceph_client_pkgs:
   - chrony
   - ceph-common
 client_group: clients
-# Bootstrap variables
-cluster: ceph
-mon_group_name: mons
-osd_group_name: osds
-rgw_group_name: rgws
-mds_group_name: mdss
-nfs_group_name: nfss
-rbdmirror_group_name: rbdmirrors
-client_group_name: clients
-iscsi_gw_group_name: iscsigws
-mgr_group_name: mgrs
-rgwloadbalancer_group_name: rgwloadbalancers
-monitoring_group_name: monitoring
-delegate_facts_host: true
-monitor_address: 'x.x.x.x'
-dashboard_enabled: true
-ceph_container_registry: docker.io
-ceph_container_image: ceph/daemon-base
-ceph_container_image_tag: latest-master
-ceph_container_registry_auth: false
-ceph_container_no_proxy: "localhost,127.0.0.1"
-configure_firewall: true
-health_mon_check_retries: 300
-health_mon_check_delay: 1

--- a/ceph-defaults/defaults/main.yml
+++ b/ceph-defaults/defaults/main.yml
@@ -16,6 +16,7 @@ ceph_pkgs:
 ceph_client_pkgs:
   - chrony
   - ceph-common
+client_group: clients
 # Bootstrap variables
 cluster: ceph
 mon_group_name: mons

--- a/cephadm-clients.yml
+++ b/cephadm-clients.yml
@@ -11,12 +11,12 @@
 # Required run-time variables
 # ------------------
 # keyring : full path name of the keyring file on the admin[0] host which holds the key for the client to use
-# client_group : ansible group name for the clients to set up
 # fsid : fsid of the cluster to extract the keyring and conf from
 #
 # Optional run-time variables
 # ------------------
 # conf : full path name of the conf file on the admin[0] host to use (undefined will trigger a minimal conf)
+# client_group : ansible group name for the clients to set up
 #
 # Example
 # -------
@@ -44,12 +44,6 @@
           You must define a group [admin] in your inventory which provides the
           keyring that you want to distribute
       when: "'admin' not in groups or groups['admin'] | length < 1"
-
-    - name: fail if client_group is empty or undefined
-      fail:
-        msg: >
-          You must supply a client_group name
-      when: client_group is undefined
 
     - name: fail if client_group is NOT in the inventory
       fail:

--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -119,7 +119,7 @@
 
     - name: install prerequisites packages
       package:
-        name: "{{ ['chrony', 'ceph-common'] if group_names == ['clients'] else ceph_pkgs | unique }}"
+        name: "{{ ['chrony', 'ceph-common'] if group_names == [client_group] else ceph_pkgs | unique }}"
         state: "{{ (upgrade_ceph_packages | bool) | ternary('latest', 'present') }}"
       register: result
       until: result is succeeded

--- a/cephadm-purge-cluster.yml
+++ b/cephadm-purge-cluster.yml
@@ -59,12 +59,15 @@
   any_errors_fatal: true
   tasks:
 
+    - import_role:
+        name: ceph-defaults
+
     - name: check cephadm binary is available
       command: which cephadm
       register: cephadm_exists
       changed_when: false
       failed_when: false
-      when: group_names != ['clients']
+      when: group_names != [client_group]
 
     - name: fail if cephadm is not available
       fail:
@@ -72,14 +75,14 @@
           The cephadm binary is missing on {{ inventory_hostname }}. To purge the cluster you must have cephadm installed
           on ALL ceph hosts. Install manually or use the preflight playbook.
       when:
-        - group_names != ['clients']
+        - group_names != [client_group]
         - cephadm_exists.rc
 
     - name: check fsid directory given is valid across the cluster
       stat:
         path: /var/lib/ceph/{{ fsid }}
       register: fsid_exists
-      when: group_names != ['clients']
+      when: group_names != [client_group]
 
     - name: fail if the fsid directory is missing
       fail:
@@ -87,7 +90,7 @@
           The fsid directory '/var/lib/ceph/{{ fsid }}' can not be found on {{ inventory_hostname }}
           Is the fsid correct?
       when:
-        - group_names != ['clients']
+        - group_names != [client_group]
         - not fsid_exists.stat.exists | bool
 
 
@@ -134,4 +137,4 @@
 
     - name: purge ceph daemons
       command: "cephadm rm-cluster --force {{ '--zap-osds' if ceph_origin == 'rhcs' or ceph_origin == 'shaman' else '' }} --fsid {{ fsid }}"
-      when: group_names != ['clients']
+      when: group_names != [client_group]

--- a/tests/functional/deploy-cluster-vars.yml
+++ b/tests/functional/deploy-cluster-vars.yml
@@ -1,0 +1,10 @@
+---
+cluster: ceph
+delegate_facts_host: true
+ceph_container_registry: docker.io
+ceph_container_image: ceph/daemon-base
+ceph_container_image_tag: latest-master
+ceph_container_registry_auth: false
+ceph_container_no_proxy: "localhost,127.0.0.1"
+health_mon_check_retries: 300
+health_mon_check_delay: 1

--- a/tests/functional/deploy-cluster.yml
+++ b/tests/functional/deploy-cluster.yml
@@ -1,15 +1,15 @@
 ---
+- name: load variables
+  hosts: all
+  become: false
+  tasks:
+    - include_vars: deploy-cluster-vars.yml
+
 - name: gather facts and prepare system for cephadm
   hosts:
-    - "{{ mon_group_name }}"
-    - "{{ osd_group_name }}"
-    - "{{ mds_group_name }}"
-    - "{{ rgw_group_name }}"
-    - "{{ mgr_group_name }}"
-    - "{{ rbdmirror_group_name }}"
-    - "{{ nfs_group_name }}"
-    - "{{ iscsi_gw_group_name }}"
-    - "{{ monitoring_group_name }}"
+    - mons
+    - mgrs
+    - osds
   become: true
   gather_facts: false
   tasks:
@@ -60,7 +60,7 @@
       when: ceph_container_registry_auth | default(False) | bool
 
 - name: bootstrap the cluster
-  hosts: "{{ mon_group_name }}[0]"
+  hosts: "{{ groups.get('mons')[0] }}"
   become: true
   gather_facts: false
   environment:
@@ -103,15 +103,9 @@
 
 - name: add the other nodes
   hosts:
-    - "{{ mon_group_name }}"
-    - "{{ osd_group_name }}"
-    - "{{ mds_group_name }}"
-    - "{{ rgw_group_name }}"
-    - "{{ mgr_group_name }}"
-    - "{{ rbdmirror_group_name}}"
-    - "{{ nfs_group_name }}"
-    - "{{ iscsi_gw_group_name }}"
-    - "{{ monitoring_group_name }}"
+    - mons
+    - mgrs
+    - osds
   become: true
   gather_facts: false
   environment:
@@ -125,7 +119,7 @@
       changed_when: false
       run_once: true
       register: cephadm_pubpkey
-      delegate_to: '{{ groups[mon_group_name][0] }}'
+      delegate_to: "{{ groups['mons'][0] }}"
 
     - name: allow cephadm key for root account
       authorized_key:
@@ -139,21 +133,21 @@
     - name: manage nodes with cephadm
       command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch host add {{ ansible_facts['hostname'] }} {{ ansible_facts['default_ipv4']['address'] }} {{ group_names | join(' ') }} {{ '_admin' if inventory_hostname == 'ceph-node0' else '' }}"
       changed_when: false
-      delegate_to: '{{ groups[mon_group_name][0] }}'
+      delegate_to: "{{ groups['mons'][0] }}"
 
     - name: add ceph label for core component
       command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch host label add {{ ansible_facts['hostname'] }} ceph"
       changed_when: false
-      delegate_to: '{{ groups[mon_group_name][0] }}'
-      when: inventory_hostname in groups.get(mon_group_name, []) or
-            inventory_hostname in groups.get(osd_group_name, []) or
-            inventory_hostname in groups.get(mds_group_name, []) or
-            inventory_hostname in groups.get(rgw_group_name, []) or
-            inventory_hostname in groups.get(mgr_group_name, []) or
-            inventory_hostname in groups.get(rbdmirror_group_name, [])
+      delegate_to: "{{ groups['mons'][0] }}"
+      when: inventory_hostname in groups.get('mons', []) or
+            inventory_hostname in groups.get('osds', []) or
+            inventory_hostname in groups.get('mdss', []) or
+            inventory_hostname in groups.get('rgws', []) or
+            inventory_hostname in groups.get('mgrs', []) or
+            inventory_hostname in groups.get('rbdmirrors', [])
 
 - name: adjust service placement
-  hosts: "{{ mon_group_name }}[0]"
+  hosts: "{{ groups.get('mons')[0] }}"
   become: true
   gather_facts: false
   environment:
@@ -163,19 +157,19 @@
         name: ceph-defaults
 
     - name: update the placement of monitor hosts
-      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch apply mon --placement='label:{{ mon_group_name }}'"
+      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch apply mon --placement='label:mons'"
       changed_when: false
 
     - name: waiting for the monitor to join the quorum...
       command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} quorum_status --format json"
       changed_when: false
       register: ceph_health_raw
-      until: (ceph_health_raw.stdout | from_json)["quorum_names"] | length == groups.get(mon_group_name, []) | length
+      until: (ceph_health_raw.stdout | from_json)["quorum_names"] | length == groups.get('mons', []) | length
       retries: "{{ health_mon_check_retries }}"
       delay: "{{ health_mon_check_delay }}"
 
     - name: update the placement of manager hosts
-      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch apply mgr --placement='label:{{ mgr_group_name }}'"
+      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch apply mgr --placement='label:mgrs'"
       changed_when: false
 
     - name: update the placement of osd hosts
@@ -187,7 +181,7 @@
       changed_when: false
 
 - name: adjust monitoring service placement
-  hosts: "{{ monitoring_group_name }}"
+  hosts: "monitoring"
   become: true
   gather_facts: false
   environment:
@@ -197,7 +191,7 @@
         name: ceph-defaults
 
     - name: dashboard related tasks
-      delegate_to: '{{ groups[mon_group_name][0] }}'
+      delegate_to: "{{ groups['mons'][0] }}"
       run_once: true
       block:
         - name: enable the prometheus module
@@ -205,15 +199,15 @@
           changed_when: false
 
         - name: update the placement of alertmanager hosts
-          command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch apply alertmanager --placement='label:{{ monitoring_group_name }}'"
+          command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch apply alertmanager --placement='label:monitoring'"
           changed_when: false
 
         - name: update the placement of grafana hosts
-          command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch apply grafana --placement='label:{{ monitoring_group_name }}'"
+          command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch apply grafana --placement='label:monitoring'"
           changed_when: false
 
         - name: update the placement of prometheus hosts
-          command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch apply prometheus --placement='label:{{ monitoring_group_name }}'"
+          command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch apply prometheus --placement='label:monitoring'"
           changed_when: false
 
         - name: update the placement of node-exporter hosts
@@ -221,7 +215,7 @@
           changed_when: false
 
 - name: print information
-  hosts: "{{ mon_group_name }}[0]"
+  hosts: "{{ groups.get('mons')[0] }}"
   become: true
   gather_facts: false
   environment:

--- a/tox.ini
+++ b/tox.ini
@@ -28,12 +28,14 @@ commands=
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 
   # Install prerequisites
-  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/cephadm-preflight.yml --extra-vars "ceph_origin=shaman"
+  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/cephadm-preflight.yml --extra-vars "\
+      ceph_origin=shaman \
+      client_group=clients \
+  "
   py.test -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts --ssh-config={changedir}/vagrant_ssh_config {changedir}/tests/
 
   # Deploy a Ceph cluster
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/deploy-cluster.yml --extra-vars "\
-      dashboard_enabled=false \
       monitor_address=192.168.9.12 \
       ceph_container_registry_auth=true \
       ceph_container_registry=quay.io \
@@ -46,8 +48,16 @@ commands=
       alertmanager_container_image=quay.io/prometheus/alertmanager:v0.20.0 \
       grafana_container_image=quay.io/ceph/ceph-grafana:6.7.4 \
       fsid=4217f198-b8b7-11eb-941d-5254004b7a69 \
-
   "
+
+  # Deploy clients using cephadm-clients.yml
+  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/cephadm-clients.yml --extra-vars "\
+      keyring=/etc/ceph/ceph.client.admin.keyring \
+      client_group=clients \
+      fsid=4217f198-b8b7-11eb-941d-5254004b7a69 \
+  "
+  #TODO(guits): add some tests
+
   # wait for all osd to be up before purging
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/wait_all_osd_are_up.yml
 


### PR DESCRIPTION
`cephadm-clients.yml` introduced the support of setting custom client
group name so we should align other playbooks with that in order to
avoid potential issues.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>