### PR TITLE
cephadm-purge: remove logic in rm-cluster task

### DIFF
--- a/cephadm-purge-cluster.yml
+++ b/cephadm-purge-cluster.yml
@@ -136,7 +136,7 @@
         name: ceph-defaults
 
     - name: purge ceph daemons
-      command: "cephadm rm-cluster --force {{ '--zap-osds' if ceph_origin == 'rhcs' or ceph_origin == 'shaman' else '' }} --fsid {{ fsid }}"
+      command: "cephadm rm-cluster --force --zap-osds --fsid {{ fsid }}"
       when: group_names != [client_group]
 
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -9,3 +9,6 @@ def node(host, request):
 
     if request.node.get_closest_marker("client") and 'clients' not in ansible_vars['group_names']:
         pytest.skip("Not a valid test for non client nodes")
+
+    if request.node.get_closest_marker("osd") and 'osds' not in ansible_vars['group_names']:
+        pytest.skip("Not a valid test for non osd nodes")

--- a/tests/functional/deploy-cluster.yml
+++ b/tests/functional/deploy-cluster.yml
@@ -173,7 +173,16 @@
       changed_when: false
 
     - name: update the placement of osd hosts
-      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch apply osd --all-available-devices"
+      shell: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch apply osd -i -"
+      args:
+        stdin: |
+          service_type: osd
+          service_id: osd
+          placement:
+            label: osds
+          spec:
+            data_devices:
+              all: true
       changed_when: false
 
     - name: update the placement of crash hosts

--- a/tests/functional/tests/test_purge.py
+++ b/tests/functional/tests/test_purge.py
@@ -1,0 +1,7 @@
+import pytest
+
+class TestPurge(object):
+    @pytest.mark.osd
+    @pytest.mark.parametrize("device", ['/dev/sda', '/dev/sdb', '/dev/sdc'])
+    def test_devices_are_available(self, host, device):
+        assert host.run('python3 -c "import os; fd = os.open({}, (os.O_RDWR | os.O_EXCL), 0); os.close(fd)"'.format(device))

--- a/tox.ini
+++ b/tox.ini
@@ -64,4 +64,6 @@ commands=
   # Purge the cluster
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/cephadm-purge-cluster.yml -e ireallymeanit=yes -e fsid=4217f198-b8b7-11eb-941d-5254004b7a69
 
+  py.test -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts --ssh-config={changedir}/vagrant_ssh_config {changedir}/tests/test_purge.py
+
   vagrant destroy -f


### PR DESCRIPTION
'--zap-osds' is now available with recent builds, let's use it.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>