### PR TITLE
cephadm-clients: add a newline in ceph.conf

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -10,5 +10,5 @@ jobs:
         with:
           python-version: '3.8'
           architecture: x64
-      - run: pip install -r <(grep ansible tests/requirements.txt) ansible-lint==4.3.7
-      - run: ansible-lint -v --force-color ./*.yml
+      - run: pip install -r <(grep ansible tests/requirements.txt) ansible-lint==5.3.2
+      - run: ansible-lint -v --force-color -c tests/ansible-lint.conf ./*.yml

--- a/cephadm-clients.yml
+++ b/cephadm-clients.yml
@@ -167,7 +167,7 @@
             dest: '/etc/ceph/ceph.keyring',
             copy_file: True }
         - { content: "{{ hostvars[groups['admin'][0]] \
-                         ['minimal_ceph_config']['stdout'] | default('') }}",
+                         ['minimal_ceph_config']['stdout'] | default('') }}{{ '\n' }}",
             dest: '/etc/ceph/ceph.conf',
             copy_file: "{{ conf is undefined }}" }
         - { content: "{{ hostvars[groups['admin'][0]] \


### PR DESCRIPTION
The generated minimal ceph.conf file is missing a newline.
This causes the following error:

```
>>>[cephuser@ceph-sunil-5-1-5ca9dc-node1-installer ~]$ ssh ceph-sunil-5-1-5ca9dc-node4 "sudo ceph -s -c  /etc/ceph/ceph.conf"
>>>Error initializing cluster client: InvalidArgumentError('RADOS invalid argument (error calling conf_read_file)',)
```

Fixes: https://tracker.ceph.com/issues/53851

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>