### PR TITLE
tests: use cephadm defaults image

### DIFF
--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -113,12 +113,18 @@
                 - ceph_stable_noarch
 
         - name: install epel-release
-          package:
-            name: epel-release
-            state: present
-          register: result
-          until: result is succeeded
           when: ansible_facts['distribution'] == 'CentOS'
+          block:
+            - name: enable CentOS PowerTools repository for epel
+              command: dnf config-manager --set-enabled powertools
+              changed_when: false
+
+            - name: install package
+              package:
+                name: epel-release
+                state: present
+              register: result
+              until: result is succeeded
 
 
         - name: install prerequisites packages

--- a/tests/functional/deploy-cluster-vars.yml
+++ b/tests/functional/deploy-cluster-vars.yml
@@ -1,7 +1,7 @@
 ---
 cluster: ceph
 delegate_facts_host: true
-ceph_container_registry: docker.io
+ceph_container_registry: quay.io
 ceph_container_image: ceph/daemon-base
 ceph_container_image_tag: latest-master
 ceph_container_registry_auth: false

--- a/tests/functional/deploy-cluster.yml
+++ b/tests/functional/deploy-cluster.yml
@@ -63,8 +63,6 @@
   hosts: "{{ groups.get('mons')[0] }}"
   become: true
   gather_facts: false
-  environment:
-    CEPHADM_IMAGE: '{{ ceph_container_registry }}/{{ ceph_container_image }}:{{ ceph_container_image_tag }}'
   tasks:
     - import_role:
         name: ceph_defaults
@@ -85,21 +83,6 @@
       command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} config set mgr mgr/cephadm/container_image_base {{ ceph_container_registry }}/{{ ceph_container_image }}"
       changed_when: false
 
-    - name: set alertmanager container image in ceph configuration
-      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} config set mgr mgr/cephadm/container_image_alertmanager {{ alertmanager_container_image }}"
-      changed_when: false
-
-    - name: set grafana container image in ceph configuration
-      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} config set mgr mgr/cephadm/container_image_grafana {{ grafana_container_image }}"
-      changed_when: false
-
-    - name: set node-exporter container image in ceph configuration
-      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} config set mgr mgr/cephadm/container_image_node_exporter {{ node_exporter_container_image }}"
-      changed_when: false
-
-    - name: set prometheus container image in ceph configuration
-      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} config set mgr mgr/cephadm/container_image_prometheus {{ prometheus_container_image }}"
-      changed_when: false
 
 - name: add the other nodes
   hosts:
@@ -108,8 +91,6 @@
     - osds
   become: true
   gather_facts: false
-  environment:
-    CEPHADM_IMAGE: '{{ ceph_container_registry }}/{{ ceph_container_image }}:{{ ceph_container_image_tag }}'
   tasks:
     - import_role:
         name: ceph_defaults
@@ -150,8 +131,6 @@
   hosts: "{{ groups.get('mons')[0] }}"
   become: true
   gather_facts: false
-  environment:
-    CEPHADM_IMAGE: '{{ ceph_container_registry }}/{{ ceph_container_image }}:{{ ceph_container_image_tag }}'
   tasks:
     - import_role:
         name: ceph_defaults
@@ -193,8 +172,6 @@
   hosts: "monitoring"
   become: true
   gather_facts: false
-  environment:
-    CEPHADM_IMAGE: '{{ ceph_container_registry }}/{{ ceph_container_image }}:{{ ceph_container_image_tag }}'
   tasks:
     - import_role:
         name: ceph_defaults
@@ -227,8 +204,6 @@
   hosts: "{{ groups.get('mons')[0] }}"
   become: true
   gather_facts: false
-  environment:
-    CEPHADM_IMAGE: '{{ ceph_container_registry }}/{{ ceph_container_image }}:{{ ceph_container_image_tag }}'
   tasks:
     - import_role:
         name: ceph_defaults

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ setenv=
   # only available for ansible >= 2.5
   ANSIBLE_STDOUT_CALLBACK = yaml
   # Set the vagrant box image to use
-  CEPH_ANSIBLE_VAGRANT_BOX = centos/8
+  CEPH_ANSIBLE_VAGRANT_BOX = centos/stream8
 
 deps= -r{toxinidir}/tests/requirements.txt
 changedir= {toxinidir}/tests/functional

--- a/tox.ini
+++ b/tox.ini
@@ -38,15 +38,8 @@ commands=
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/tests/functional/deploy-cluster.yml --extra-vars "\
       monitor_address=192.168.9.12 \
       ceph_container_registry_auth=true \
-      ceph_container_registry=quay.io \
-      ceph_container_image=ceph/daemon-base \
-      ceph_container_image_tag=latest-master-devel \
       ceph_container_registry_username={env:QUAY_IO_USERNAME} \
       ceph_container_registry_password={env:QUAY_IO_PASSWORD} \
-      node_exporter_container_image=quay.io/prometheus/node-exporter:v0.18.1 \
-      prometheus_container_image=quay.io/prometheus/prometheus:v2.18.1 \
-      alertmanager_container_image=quay.io/prometheus/alertmanager:v0.20.0 \
-      grafana_container_image=quay.io/ceph/ceph-grafana:6.7.4 \
       fsid=4217f198-b8b7-11eb-941d-5254004b7a69 \
   "
 


### PR DESCRIPTION
So we don't have to maintain this in the tox.ini file.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>