### PR TITLE
tests: do not set default image

### DIFF
--- a/tests/functional/deploy-cluster-vars.yml
+++ b/tests/functional/deploy-cluster-vars.yml
@@ -2,8 +2,6 @@
 cluster: ceph
 delegate_facts_host: true
 ceph_container_registry: quay.io
-ceph_container_image: ceph/daemon-base
-ceph_container_image_tag: latest-master
 ceph_container_registry_auth: false
 ceph_container_no_proxy: "localhost,127.0.0.1"
 health_mon_check_retries: 300

--- a/tests/functional/deploy-cluster.yml
+++ b/tests/functional/deploy-cluster.yml
@@ -75,14 +75,6 @@
     - name: bootstrap initial cluster
       command: "{{ cephadm_cmd }} bootstrap --mon-ip {{ monitor_address }} --skip-pull --skip-dashboard --skip-monitoring-stack {{ '--fsid ' + fsid if fsid is defined else '' }}"
 
-    - name: set default container image in ceph configuration
-      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} config set global container_image {{ ceph_container_registry }}/{{ ceph_container_image }}:{{ ceph_container_image_tag }}"
-      changed_when: false
-
-    - name: set container image base in ceph configuration
-      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} config set mgr mgr/cephadm/container_image_base {{ ceph_container_registry }}/{{ ceph_container_image }}"
-      changed_when: false
-
 
 - name: add the other nodes
   hosts:


### PR DESCRIPTION
There's no need to set the images when bootstrapping given that
we wan't to use default images from cephadm itself.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>