### PR TITLE
tests: get a system up-to-date before deploying

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,9 @@ commands=
   bash {toxinidir}/tests/scripts/vagrant_up.sh --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 
+  # Get a system up-to-date before deploying
+  ansible -vv -i {changedir}/hosts all -b -m command -a 'dnf update -y'
+
   # Install prerequisites
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/cephadm-preflight.yml --extra-vars "\
       ceph_origin=shaman \


### PR DESCRIPTION
At the moment, we can see failures like the following:

```
/bin/podman: symbol lookup error: /bin/podman: undefined symbol: seccomp_notify_fd
```

when running any podman commands.
This is because of system not up-to-date.
Having a system up-to-date before doing any operations should be considered as a
requirement.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>