### PR TITLE
preflight: drop client support

### DIFF
--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -17,20 +17,6 @@
 #
 # ansible-playbook -i <inventory host file> cephadm-preflight.yml --extra-vars "ceph_origin=rhcs"
 #
-# If you plan to deploy 'client' nodes, you must add a group called 'clients' in your inventory:
-#
-# $ cat hosts
-# mynode1
-# mynode2
-# mynode3
-#
-# [clients]
-# client1
-# client2
-# client3
-#
-# Then, you can run the the same way as shown above. The playbook will automatically install
-# chronyd and ceph-common on those nodes.
 
 - hosts: all
   become: true
@@ -153,7 +139,7 @@
 
         - name: install prerequisites packages
           package:
-            name: "{{ ceph_client_pkgs if group_names == [client_group] else ceph_pkgs | unique }}"
+            name: "{{ ceph_pkgs }}"
             state: "{{ (upgrade_ceph_packages | bool) | ternary('latest', 'present') }}"
           register: result
           until: result is succeeded
@@ -200,7 +186,7 @@
 
         - name: install prerequisites packages
           apt:
-            name: "{{ 'ceph-common' if group_names == [client_group] else ['python3','cephadm','ceph-common'] | unique }}"
+            name: "{{ ['python3','cephadm','ceph-common'] }}"
             state: "{{ (upgrade_ceph_packages | bool) | ternary('latest', 'present') }}"
             update_cache: yes
           register: result
@@ -209,7 +195,7 @@
         - name: install container engine
           block:
             - name: install podman
-              when: ansible_facts['distribution_version'] is version('20.10', '>=') and group_names != [client_group]
+              when: ansible_facts['distribution_version'] is version('20.10', '>=')
               apt:
                 name: podman
                 state: present
@@ -218,7 +204,7 @@
               until: result is succeeded
 
             - name: install docker
-              when: ansible_facts['distribution_version'] is version('20.10', '<') and group_names != [client_group]
+              when: ansible_facts['distribution_version'] is version('20.10', '<')
               block:
                 - name: uninstall old version packages
                   apt:

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ commands=
 
   # Install prerequisites
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/cephadm-preflight.yml --extra-vars "\
-      ceph_origin=shaman \
+      ceph_origin=community \
       client_group=clients \
   "
   py.test -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts --ssh-config={changedir}/vagrant_ssh_config {changedir}/tests/test_preflight.py

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,8 @@ commands=
   bash {toxinidir}/tests/scripts/vagrant_up.sh --no-provision {posargs:--provider=virtualbox}
   bash {toxinidir}/tests/scripts/generate_ssh_config.sh {changedir}
 
+  ansible -v -i {changedir}/hosts all -b -m command -a 'dnf update -y'
+
   # Install prerequisites
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/cephadm-preflight.yml --extra-vars "\
       ceph_origin=community \


### PR DESCRIPTION
Given that we have a dedicated playbook for that, there's no need to
handle client configuration in this playbook.

Fixes: #27

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit e15118f74cf10acf2f9045bf4bed2a3c7e43bdd4)