### PR TITLE
cephadm-clients: add new parameter 'keyring_dest'

### DIFF
--- a/cephadm-clients.yml
+++ b/cephadm-clients.yml
@@ -17,6 +17,7 @@
 # ------------------
 # conf : full path name of the conf file on the admin[0] host to use (undefined will trigger a minimal conf)
 # client_group : ansible group name for the clients to set up
+# keyring_dest : full path name of the destination where the keyring will be copied. (default: /etc/ceph/ceph.keyring)
 #
 # Example
 # -------
@@ -164,7 +165,7 @@
       loop:
         - { content: "{{ hostvars[groups['admin'][0]] \
                          ['client_keyring']['content'] | b64decode }}",
-            dest: '/etc/ceph/ceph.keyring',
+            dest: "{{ keyring_dest | default('/etc/ceph/ceph.keyring') }}",
             copy_file: True }
         - { content: "{{ hostvars[groups['admin'][0]] \
                          ['minimal_ceph_config']['stdout'] | default('') }}{{ '\n' }}",

--- a/tests/scripts/vagrant_up.sh
+++ b/tests/scripts/vagrant_up.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+vagrant box remove centos/stream8 --all --force || true
+vagrant box add --name centos/stream8 https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-20220125.1.x86_64.vagrant-libvirt.box --force
+
 retries=0
 until [ $retries -ge 5 ]
 do


### PR DESCRIPTION
This adds a new parameter 'keyring_dest' so we can override
the default destination where the keyring will be copied
(/etc/ceph/ceph.keyring).

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2028628

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>