### PR TITLE
preflight/clients: workaround packaging issue

### DIFF
--- a/cephadm-clients.yml
+++ b/cephadm-clients.yml
@@ -140,12 +140,19 @@
 - name: Distribute client configuration
   hosts: "{{ client_group }}"
   become: yes
-  gather_facts: false
+  gather_facts: true
   tasks:
 
     - name: import_role ceph_defaults
       import_role:
         name: ceph_defaults
+
+    - name: install ceph-common on rhel
+      command: dnf install --allowerasing --assumeyes ceph-common
+      changed_when: false
+      register: result
+      until: result is succeeded
+      when: ansible_facts['distribution'] == 'CentOS' or ansible_facts['distribution'] == 'RedHat'
 
     - name: install ceph client prerequisites if needed
       package:

--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -43,6 +43,15 @@
               rhsm_repository:
                 name: "rhceph-{{ ceph_rhcs_version }}-tools-for-rhel-8-{{ ansible_facts['architecture'] }}-rpms"
 
+            - name: disable older rhceph repositories if any
+              rhsm_repository:
+                name: "{{ item }}"
+                state: absent
+              loop:
+                - rhceph-4-tools-for-rhel-8-{{ ansible_facts['architecture'] }}-rpms
+                - rhceph-4-mon-for-rhel-8-{{ ansible_facts['architecture'] }}-rpms
+                - rhceph-4-osd-for-rhel-8-{{ ansible_facts['architecture'] }}-rpms
+
         - name: enable repo from download.ceph.com
           when: ceph_origin == 'community'
           block:
@@ -136,6 +145,11 @@
               register: result
               until: result is succeeded
 
+        - name: install ceph-common on rhel
+          command: dnf install --allowerasing --assumeyes ceph-common
+          changed_when: false
+          register: result
+          until: result is succeeded
 
         - name: install prerequisites packages
           package:


### PR DESCRIPTION
After an upgrade from RHCS 4, we must be sure ceph-common-14.x is
uninstalled before installing that package from rhceph-5 repository.
Otherwise, it leads to dependencies errors like following:

```
    Depsolve Error occured:
     Problem: problem with installed package ceph-osd-2:14.2.11-184.el8cp.x86_64
      - package ceph-osd-2:14.2.11-184.el8cp.x86_64 requires ceph-base = 2:14.2.11-184.el8cp, but none of the providers can be installed
      - package ceph-osd-2:14.2.4-125.el8cp.x86_64 requires ceph-base = 2:14.2.4-125.el8cp, but none of the providers can be installed
```

This could be addressed by using the `allowerasing` option of the ansible module `package`
but this option is available in 2.10 onward only.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2008402

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>