### PR TITLE
preflight/clients: workaround packaging issue

### DIFF
--- a/cephadm-clients.yml
+++ b/cephadm-clients.yml
@@ -140,12 +140,19 @@
 - name: Distribute client configuration
   hosts: "{{ client_group }}"
   become: yes
-  gather_facts: false
+  gather_facts: true
   tasks:
 
     - name: import_role ceph_defaults
       import_role:
         name: ceph_defaults
+
+    - name: install ceph-common on rhel
+      command: dnf install --allowerasing --assumeyes ceph-common
+      changed_when: false
+      register: result
+      until: result is succeeded
+      when: ansible_facts['distribution'] == 'CentOS' or ansible_facts['distribution'] == 'RedHat'
 
     - name: install ceph client prerequisites if needed
       package:

--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -135,11 +135,18 @@
               until: result is succeeded
 
         - name: install epel-release
-          package:
-            name: epel-release
-            state: present
-          register: result
-          until: result is succeeded
+          when: ansible_facts['distribution'] == 'CentOS'
+          block:
+            - name: enable CentOS PowerTools repository for epel
+              command: dnf config-manager --set-enabled powertools
+              changed_when: false
+
+            - name: install package
+              package:
+                name: epel-release
+                state: present
+              register: result
+              until: result is succeeded
 
         - name: configure red hat ceph stable community repository
           yum_repository:

--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -57,6 +57,15 @@
               rhsm_repository:
                 name: "rhceph-{{ ceph_rhcs_version }}-tools-for-rhel-8-{{ ansible_facts['architecture'] }}-rpms"
 
+            - name: disable older rhceph repositories if any
+              rhsm_repository:
+                name: "{{ item }}"
+                state: absent
+              loop:
+                - rhceph-4-tools-for-rhel-8-{{ ansible_facts['architecture'] }}-rpms
+                - rhceph-4-mon-for-rhel-8-{{ ansible_facts['architecture'] }}-rpms
+                - rhceph-4-osd-for-rhel-8-{{ ansible_facts['architecture'] }}-rpms
+
         - name: enable repo from download.ceph.com
           when: ceph_origin == 'community'
           block:
@@ -158,6 +167,17 @@
             baseurl: "{{ ceph_mirror }}/rpm-{{ ceph_release }}/el{{ ansible_facts['distribution_major_version'] }}/$basearch"
             file: ceph_stable
             priority: '2'
+
+        - name: install ceph-common on rhel
+          command: dnf install --allowerasing --assumeyes ceph-common
+          changed_when: false
+          register: result
+          until: result is succeeded
+
+        - name: install prerequisites packages
+          package:
+            name: "{{ ceph_pkgs }}"
+            state: "{{ (upgrade_ceph_packages | bool) | ternary('latest', 'present') }}"
           register: result
           until: result is succeeded
 


### PR DESCRIPTION
After an upgrade from RHCS 4, we must be sure ceph-common-14.x is
uninstalled before installing that package from rhceph-5 repository.
Otherwise, it leads to dependencies errors like following:

```
    Depsolve Error occured:
     Problem: problem with installed package ceph-osd-2:14.2.11-184.el8cp.x86_64
      - package ceph-osd-2:14.2.11-184.el8cp.x86_64 requires ceph-base = 2:14.2.11-184.el8cp, but none of the providers can be installed
      - package ceph-osd-2:14.2.4-125.el8cp.x86_64 requires ceph-base = 2:14.2.4-125.el8cp, but none of the providers can be installed
```

This could be addressed by using the `allowerasing` option of the ansible module `package`
but this option is available in 2.10 onward only.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2008402

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit https://github.com/ceph/cephadm-ansible/commit/c5beec4fcb74b121603a05ce1408f01b12019c44)