### PR TITLE
preflight/clients: workaround packaging issue

### DIFF
--- a/cephadm-clients.yml
+++ b/cephadm-clients.yml
@@ -140,12 +140,19 @@
 - name: Distribute client configuration
   hosts: "{{ client_group }}"
   become: yes
-  gather_facts: false
+  gather_facts: true
   tasks:
 
     - name: import_role ceph_defaults
       import_role:
         name: ceph_defaults
+
+    - name: install ceph-common on rhel
+      command: dnf install --allowerasing --assumeyes ceph-common
+      changed_when: false
+      register: result
+      until: result is succeeded
+      when: ansible_facts['distribution'] == 'CentOS' or ansible_facts['distribution'] == 'RedHat'
 
     - name: install ceph client prerequisites if needed
       package:

--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -132,6 +132,12 @@
       until: result is succeeded
       when: ansible_facts['distribution'] == 'CentOS'
 
+    - name: install ceph-common on rhel
+      command: dnf install --allowerasing --assumeyes ceph-common
+      changed_when: false
+      register: result
+      until: result is succeeded
+
     - name: install prerequisites packages
       package:
         name: "{{ ceph_client_pkgs if group_names == [client_group] else ceph_pkgs | unique }}"

--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -47,70 +47,6 @@
         - ceph_origin == 'custom'
         - custom_repo_url is undefined
 
-    - name: redhat family of OS related tasks
-      when: ansible_facts['distribution'] == 'CentOS' or ansible_facts['distribution'] == 'RedHat'
-      block:
-        - name: rhcs related tasks
-          when: ceph_origin == 'rhcs'
-          block:
-            - name: enable red hat storage tools repository
-              rhsm_repository:
-                name: "rhceph-{{ ceph_rhcs_version }}-tools-for-rhel-8-{{ ansible_facts['architecture'] }}-rpms"
-
-        - name: enable repo from download.ceph.com
-          when: ceph_origin == 'community'
-          block:
-            - name: configure red hat ceph community repository stable key
-              rpm_key:
-                key: "{{ ceph_stable_key }}"
-                state: present
-              register: result
-              until: result is succeeded
-
-            - name: configure red hat ceph stable community repository
-              yum_repository:
-                name: ceph_stable
-                description: Ceph Stable $basearch repo
-                gpgcheck: yes
-                state: present
-                gpgkey: "{{ ceph_stable_key }}"
-                baseurl: "{{ ceph_mirror }}/rpm-{{ ceph_release }}/el{{ ansible_facts['distribution_major_version'] }}/$basearch"
-                file: ceph_stable
-                priority: '2'
-              register: result
-              until: result is succeeded
-
-            - name: configure red hat ceph stable noarch community repository
-              yum_repository:
-                name: ceph_stable_noarch
-                description: Ceph Stable noarch repo
-                gpgcheck: yes
-                state: present
-                gpgkey: "{{ ceph_stable_key }}"
-                baseurl: "{{ ceph_mirror }}/rpm-{{ ceph_release }}/el{{ ansible_facts['distribution_major_version'] }}/noarch"
-                file: ceph_stable
-                priority: '2'
-              register: result
-              until: result is succeeded
-
-        - name: enable repo from shaman - dev
-          when: ceph_origin == 'shaman'
-          block:
-            - name: fetch ceph red hat development repository
-              uri:
-                url: https://shaman.ceph.com/api/repos/ceph/{{ ceph_dev_branch }}/{{ ceph_dev_sha1 }}/centos/{{ ansible_facts['distribution_major_version'] }}/repo?arch={{ ansible_facts['architecture'] }}  # noqa 204
-                return_content: yes
-              register: ceph_dev_yum_repo
-
-            - name: configure ceph red hat development repository
-              copy:
-                content: "{{ ceph_dev_yum_repo.content }}"
-                dest: /etc/yum.repos.d/ceph-dev.repo
-                owner: root
-                group: root
-                mode: '0644'
-                backup: yes
-
     - name: rhcs related tasks
       when: ceph_origin == 'rhcs'
       block:
@@ -118,25 +54,12 @@
           rhsm_repository:
             name: "rhceph-{{ ceph_rhcs_version }}-tools-for-rhel-8-{{ ansible_facts['architecture'] }}-rpms"
 
-        - name: enable custom repo
-          when: ceph_origin == 'custom'
-          block:
-            - name: setup custom repository
-              yum_repository:
-                name: ceph_custom
-                description: Ceph custom repo
-                gpgcheck: "{{ 'yes' if custom_repo_gpgkey is defined else 'no' }}"
-                state: present
-                gpgkey: "{{ custom_repo_gpgkey | default(omit) }}"
-                baseurl: "{{ custom_repo_url }}"
-                file: ceph_custom
-                priority: '2'
-              register: result
-              until: result is succeeded
-
-        - name: install epel-release
-          package:
-            name: epel-release
+    - name: enable repo from download.ceph.com
+      when: ceph_origin == 'community'
+      block:
+        - name: configure red hat ceph community repository stable key
+          rpm_key:
+            key: "{{ ceph_stable_key }}"
             state: present
           register: result
           until: result is succeeded
@@ -185,14 +108,21 @@
             mode: '0644'
             backup: yes
 
-        - name: remove ceph_stable repositories
+    - name: enable custom repo
+      when: ceph_origin == 'custom'
+      block:
+        - name: setup custom repository
           yum_repository:
-            name: '{{ item }}'
-            file: ceph_stable
-            state: absent
-          with_items:
-            - ceph_stable
-            - ceph_stable_noarch
+            name: ceph_custom
+            description: Ceph custom repo
+            gpgcheck: "{{ 'yes' if custom_repo_gpgkey is defined else 'no' }}"
+            state: present
+            gpgkey: "{{ custom_repo_gpgkey | default(omit) }}"
+            baseurl: "{{ custom_repo_url }}"
+            file: ceph_custom
+            priority: '2'
+          register: result
+          until: result is succeeded
 
     - name: install epel-release
       package:
@@ -201,7 +131,6 @@
       register: result
       until: result is succeeded
       when: ansible_facts['distribution'] == 'CentOS'
-
 
     - name: install prerequisites packages
       package:


### PR DESCRIPTION
After an upgrade from RHCS 4, we must be sure ceph-common-14.x is
uninstalled before installing that package from rhceph-5 repository.
Otherwise, it leads to dependencies errors like following:

```
    Depsolve Error occured:
     Problem: problem with installed package ceph-osd-2:14.2.11-184.el8cp.x86_64
      - package ceph-osd-2:14.2.11-184.el8cp.x86_64 requires ceph-base = 2:14.2.11-184.el8cp, but none of the providers can be installed
      - package ceph-osd-2:14.2.4-125.el8cp.x86_64 requires ceph-base = 2:14.2.4-125.el8cp, but none of the providers can be installed
```

This could be addressed by using the `allowerasing` option of the ansible module `package`
but this option is available in 2.10 onward only.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2008402

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>