### PR TITLE
Quincy backport of pr #57

### DIFF
--- a/cephadm-ansible.spec.in
+++ b/cephadm-ansible.spec.in
@@ -25,7 +25,7 @@ cephadm-ansible is a collection of Ansible playbooks to simplify workflows that 
 %install
 mkdir -p %{buildroot}%{_datarootdir}/cephadm-ansible
 
-for f in ansible.cfg *.yml ceph_defaults; do
+for f in ansible.cfg *.yml ceph_defaults library module_utils; do
   cp -a $f %{buildroot}%{_datarootdir}/cephadm-ansible
 done
 

--- a/doc/source/Makefile
+++ b/doc/source/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,0 +1,55 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'cephadm-ansible'
+copyright = '2022, Red Hat'
+author = 'Guillaume Abrioux'
+
+# The full version, including alpha/beta/rc tags
+release = 'v2.0'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,0 +1,419 @@
+.. contents::
+
+Introduction
+------------
+
+cephadm-ansible is a collection of Ansible modules and playbooks to simplify
+workflows that are not covered by [cephadm]_. The following workflows are covered
+by three playbooks:
+
+* cephadm-preflight.yml: Initial setup of hosts before bootstrapping the cluster
+* cephadm-clients.yml: Setting up client hosts
+* cephadm-purge-cluster.yml: Remove a Ceph cluster
+
+Additionnally, several ansible modules are provided in order to let people writing their own playbooks.
+
+
+.. [cephadm] https://docs.ceph.com/en/quincy/cephadm/
+
+Terminology
+-----------
+
+**admin host**
+  A host where the admin keyring and ceph config file is present. Although the admin host and the bootstrap host are usually the same host, it is possible to have multiple admin hosts later.
+  ``cephadm`` will make a host become 'admin' when the label ``_admin`` is added to that host. (ie: ``ceph orch host label add <host> _admin``).
+  This hosts should be present in the group ``[admin]`` in the ansible inventory.
+  If for some reason you decide a host shouldn't be a 'admin host' anymore, you have to :
+
+  * remove it from the group ``[admin]`` in the ansible inventory,
+  * remove the admin keyring,
+  * remove the ceph config file,
+  * remove the ``_admin`` label. (ie ``ceph orch host label rm <host> _admin``)
+
+
+**ansible host**
+  The host where any cephadm-ansible playbook is run.
+
+**bootstrap host**
+  The host where the ceph cluster will start. Unless you pass the ``--skip-admin-label`` option to the ``ceph bootstram`` command, this host will receive the admin keyring and the ceph config file and should be considered as an 'admin host'.
+  This host should be present in the group ``[admin]`` in the ansible inventory.
+
+
+Ansible inventory
+-----------------
+The ansible inventory is a file where all the hosts intended to be part of the ceph cluster will be listed.
+The most common format are INI or YAML.
+
+Although you probably want to keep it as simple as possible, you can organize your inventory and create groups, `cephadm-ansible` won't differentiate except for the following requirements:
+
+* Client hosts must be defined in a dedicated group ``[clients]``.
+* Both ``cephadm-purge-cluster.yml`` and ``cephadm-clients.yml`` playbooks require a group ``[admin]`` with at least one admin host (usually it will be the bootstrap node).
+
+.. note:: the name of the client group can be changed. In that case you have to set the variable `client_group`.
+
+Otherwise, you can create groups such as ``[monitors]``, ``[osds]``, ``[rgws]``, that might help you keep clarity in your inventory file and ease the ``--limit`` usage if you plan to use it to target specific a group of hosts only.
+
+A basic inventory would look like following::
+
+   # cat hosts
+   ceph-mon1
+   ceph-mon2
+   ceph-mon3
+   ceph-osd1
+   ceph-osd2
+   ceph-osd3
+   ceph-mds1
+   ceph-mds2
+   ceph-rgw1
+   ceph-rgw2
+
+   [clients]
+   ceph-client1
+   ceph-client2
+   ceph-client3
+
+   [admin]
+   ceph-mon1
+
+
+Playbooks
+---------
+
+cephadm-preflight
+=================
+
+This playbook configures the Ceph repository.
+It also installs some prerequisites (podman, lvm2, chronyd, cephadm, ...)
+
+Usage::
+
+   ansible-playbook -i <inventory host file> cephadm-preflight.yml
+
+
+You can limit the execution to a set of hosts by using ``--limit`` option::
+
+   ansible-playbook -i <inventory host file> cephadm-preflight.yml --limit <my_osd_group|my_node_name>
+
+
+You can override variables using ``--extra-vars`` parameter::
+
+
+   ansible-playbook -i <inventory host file> cephadm-preflight.yml --extra-vars "ceph_origin=rhcs"
+
+
+
+Options
++++++++
+
+ceph_origin
+~~~~~~~~~~~
+**description**
+  The source of Ceph repositories.
+
+
+**valid values**
+
+``rhcs``
+  Repository from Red Hat Ceph Storage.
+``community``
+  Community repository (https://download.ceph.com)
+``custom``
+  Custom repository.
+``shaman``
+  Devel repository.
+
+**default**
+  "community"
+
+ceph_stable_key
+~~~~~~~~~~~~~~~~
+**description**
+  URL to the gpg key.
+
+**default**
+  https://download.ceph.com/keys/release.asc
+
+ceph_release
+~~~~~~~~~~~~
+**description**
+  The release of Ceph.
+
+**default**
+  Corresponding Ceph release.
+
+ceph_dev_branch
+~~~~~~~~~~~~~~~
+**description**
+  The development branch to be used in shaman when `ceph_origin` is 'shaman'.
+
+**default**
+  "master"
+
+ceph_dev_sha1
+~~~~~~~~~~~~~
+**description**
+  The sha1 corresponding to the build to be used when `ceph_origin` is 'shaman'.
+
+**default**
+  "latest"
+
+custom_repo_url
+~~~~~~~~~~~~~~~
+**description**
+  The url of the repository when ``ceph_origin`` is 'custom'.
+
+
+custom_repo_gpgkey
+~~~~~~~~~~~~~~~~~~
+**description**
+  The url of the gpg key corresponding to the repository set in ``custom_repo_url`` when ``ceph_origin`` is 'custom'.
+
+cephadm-purge
+=============
+
+This playbook purges a Ceph cluster managed with cephadm
+
+You must define a group ``[admin]`` in your inventory with a node where
+the admin keyring is present at ``/etc/ceph/ceph.client.admin.keyring``
+
+Usage::
+
+   ansible-playbook -i <inventory host file> cephadm-purge-cluster.yml -e fsid=<your fsid>
+
+Options
++++++++
+
+fsid
+~~~~
+**description**
+  The fsid of the cluster.
+
+
+cephadm-clients
+===============
+
+If you plan to deploy client nodes, you must define a group called "clients" in your inventory::
+
+   $ cat hosts
+   node1
+   node2
+   node3
+
+   [clients]
+   client1
+   client2
+   client3
+   node123
+
+This playbooks distribute keyring and conf files to a set of client hosts.
+
+Usage::
+
+   ansible-playbook -i <inventory host file> cephadm-clients.yml -e fsid=<cluster fsid> -e keyring=<path to the keyring>
+
+Options
++++++++
+
+keyring
+~~~~~~~~
+**description**
+  The full path name of the keyring file on the host (which should be admin[0]) which holds the key for the client to use
+
+conf
+~~~~
+**description**
+  The full path name of the conf file on the (which should be admin[0]) host to use (undefined will trigger a minimal conf)
+
+keyring_dest
+~~~~~~~~~~~~
+**description**
+  The full path name of the destination where the keyring will be copied on the remote host. (default: /etc/ceph/ceph.keyring)
+
+Modules
+-------
+
+Introduction
+============
+
+cephadm-ansible provides several modules to make it easier to write playbooks around cephadm/ceph orch.
+The idea is to let you write your own playbooks, rather than providing a unique playbook that would try to cover anyone's use case.
+This way you can have a solution that fits better with your needs.
+
+At the moment only the most important tasks are supported.
+This means that any operation not covered would have to be done either with either the ``command`` or ``shell`` Ansible tasks in your playbook.
+
+Module descriptions
+===================
+
+cephadm_bootstrap
++++++++++++++++++
+
+``mon_ip``
+  Ceph monitor IP address.
+``image``
+  Ceph container image.
+``docker``
+  Use docker instead of podman.
+``fsid``
+  Ceph FSID.
+``pull``
+  Pull the Ceph container image.
+``dashboard``
+  Deploy the Ceph dashboard.
+``dashboard_user``
+  Ceph dashboard user.
+``dashboard_password``
+  Ceph dashboard password.
+``monitoring``
+  Deploy the monitoring stack.
+``firewalld``
+  Manage firewall rules with firewalld.
+``allow_overwrite``
+  allow overwrite of existing -output-* config/keyring/ssh files.
+``registry_url``
+  URL for custom registry.
+``registry_username``
+  Username for custom registry.
+``registry_password``
+  Password for custom registry.
+``registry_json``
+  JSON file with custom registry login info (URL, username, password).
+``ssh_user``
+  SSH user used for cephadm ssh to the hosts.
+``ssh_config``
+  SSH config file path for cephadm ssh client.
+
+
+ceph_orch_host
+++++++++++++++
+
+``fsid``
+  The fsid of the Ceph cluster to interact with.
+``name``
+  name of the host to be added/removed/updated.
+``address``
+  address of the host, required when ``state`` is ``present``.
+``set_admin_label``
+  enforce '_admin' label on the host specified in 'name'.
+``labels``
+  list of labels to apply on the host.
+``state``
+  If set to 'present', it will ensure the host specified in 'name' will be present along with the labels specified in ``labels``.
+  If set to 'absent', it will remove the host specified in 'name'.
+  If set to 'drain', it will schedule to remove all daemons from the host specified in 'name'.
+
+
+ceph_config
++++++++++++
+
+``fsid``
+  The fsid of the Ceph cluster to interact with.
+``action``
+  Whether to get or set the parameter specified in 'option'.
+``who``
+  Which daemon the configuration should be set to.
+``option``
+  Name of the parameter to be set.
+``value``
+  Value of the parameter to set.
+
+ceph_orch_apply
++++++++++++++++
+
+``fsid``
+  The fsid of the Ceph cluster to interact with.
+``spec``
+  The service spec to apply.
+
+
+ceph_orch_daemon
+++++++++++++++++
+
+``fsid``
+  The fsid of the Ceph cluster to interact with.
+``state``
+  The desired state of the service specified in 'name'.
+  If 'started', it ensures the service is started.
+  If 'stopped', it ensures the service is stopped.
+  If 'restarted', it will restart the service.
+``service_id``
+  The id of the service.
+``service_type``
+  The type of the service.
+
+Samples
+=======
+
+This shows how the supported modules can be used in a playbook.
+This doesn't cover the pre-requisites steps (preflight, ...) so it implies all requirements are satisfied (podman, lvm2,...).
+It assumes your "bootstrap host" (or "admin host") can ssh to other hosts with root user without password.
+
+Bootstrap and add some hosts::
+
+   # cat hosts
+   ceph-mon1 monitor_address=10.10.10.101 labels="['_admin', 'mon', 'mgr']"
+   ceph-mon2 labels="['mon', 'mgr']"
+   ceph-mon3 labels="['mon', 'mgr']"
+   ceph-osd1 labels="['osd']"
+   ceph-osd2 labels="['osd']"
+   ceph-osd3 labels="['osd']"
+   # cat site.yml
+   ---
+   - name: bootstrap the cluster
+     hosts: ceph-node01
+     become: true
+     gather_facts: false
+     tasks:
+       - name: bootstrap initial cluster
+         cephadm_bootstrap:
+           mon_ip: "{{ monitor_address }}"
+
+   - name: add more hosts
+     hosts: all
+     become: true
+     gather_facts: true
+     tasks:
+       - name: add hosts to the cluster
+         ceph_orch_host:
+           name: "{{ ansible_facts['hostname'] }}"
+           address: "{{ ansible_facts['default_ipv4']['address'] }}"
+           labels: "{{ labels }}"
+         delegate_to: ceph-mon1
+
+   - name: deploy osd service
+     hosts: ceph-node01
+     become: true
+     gather_facts: false
+     tasks:
+       - name: apply osd spec
+         ceph_orch_apply:
+         spec: |
+            service_type: osd
+            service_id: osd
+              placement:
+            label: osd
+            spec:
+              data_devices:
+                all: true
+
+   - name: change osd_default_notify_timeout option
+     hosts: ceph-node01
+     become: true
+     gather_facts: false
+     tasks:
+       - name: decrease the value of osd_default_notify_timeout option
+         ceph_config:
+           action: set
+           who: osd
+           option: osd_default_notify_timeout
+           value: 20
+
+
+.. note:: You may have noticed that most of the time, the target node in the different plays in the playbook above is ``ceph-node01``, which is the bootstrap node.
+
+Upcoming changes
+----------------
+
+.. important:: The name of the project might change in the next release.
+
+.. important:: In the next release, this project will be distributed as an Ansible collection.

--- a/doc/source/make.bat
+++ b/doc/source/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/library/ceph_config.py
+++ b/library/ceph_config.py
@@ -116,6 +116,7 @@ def main() -> None:
         module.exit_json(
             changed=False,
             stdout='',
+            cmd=[],
             stderr='',
             rc=0,
             start='',

--- a/library/ceph_config.py
+++ b/library/ceph_config.py
@@ -1,0 +1,144 @@
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+# Author: Guillaume Abrioux <gabrioux@redhat.com>
+
+from __future__ import absolute_import, division, print_function
+from typing import List, Tuple
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule  # type: ignore
+try:
+    from ansible.module_utils.ceph_common import exit_module, build_base_cmd_sh  # type: ignore
+except ImportError:
+    from module_utils.ceph_common import exit_module, build_base_cmd_sh  # type: ignore
+
+import datetime
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: ceph_config
+short_description: set ceph config
+version_added: "2.10"
+description:
+    - Set Ceph config options.
+options:
+    fsid:
+        description:
+            - the fsid of the Ceph cluster to interact with.
+        required: false
+    action:
+        description:
+            - whether to get or set the parameter specified in 'option'
+        required: false
+        default: 'set'
+    who:
+        description:
+            - which daemon the configuration should be set to
+        required: true
+    option:
+        description:
+            - name of the parameter to be set
+        required: true
+    value:
+        description:
+            - value of the parameter
+        required: true if action is 'set'
+
+author:
+    - Guillaume Abrioux <gabrioux@redhat.com>
+'''
+
+EXAMPLES = '''
+- name: set osd_memory_target for osd.0
+  ceph_config:
+    action: set
+    who: osd.0
+    option: osd_memory_target
+    value: 5368709120
+
+- name: set osd_memory_target for host ceph-osd-02
+  ceph_config:
+    action: set
+    who: osd/host:ceph-osd-02
+    option: osd_memory_target
+    value: 5368709120
+
+- name: get osd_pool_default_size value
+  ceph_config:
+    action: get
+    who: global
+    option: osd_pool_default_size
+    value: 1
+'''
+
+RETURN = '''#  '''
+
+
+def get_or_set_option(module: "AnsibleModule",
+                      action: str,
+                      who: str,
+                      option: str,
+                      value: str) -> Tuple[int, List[str], str, str]:
+    cmd = build_base_cmd_sh(module)
+    cmd.extend(['ceph', 'config', 'get', who, option])
+
+    rc, out, err = module.run_command(cmd)
+
+    return rc, cmd, out.strip(), err
+
+
+def main() -> None:
+    module = AnsibleModule(
+        argument_spec=dict(
+            who=dict(type='str', required=True),
+            action=dict(type='str', required=False, choices=['get', 'set'], default='set'),
+            option=dict(type='str', required=True),
+            value=dict(type='str', required=False),
+            fsid=dict(type='str', required=False)
+        ),
+        supports_check_mode=True,
+        required_if=[['action', 'set', ['value']]]
+    )
+
+    # Gather module parameters in variables
+    who = module.params.get('who')
+    option = module.params.get('option')
+    value = module.params.get('value')
+    action = module.params.get('action')
+
+    if module.check_mode:
+        module.exit_json(
+            changed=False,
+            stdout='',
+            stderr='',
+            rc=0,
+            start='',
+            end='',
+            delta='',
+        )
+
+    startd = datetime.datetime.now()
+    changed = False
+
+    rc, cmd, out, err = get_or_set_option(module, 'get', who, option, value)
+
+    if action == 'set':
+        if value == out:
+            out = 'who={} option={} value={} already set. Skipping.'.format(who, option, value)
+        else:
+            rc, cmd, out, err = get_or_set_option(module, action, who, option, value)
+            changed = True
+
+    exit_module(module=module, out=out, rc=rc,
+                cmd=cmd, err=err, startd=startd,
+                changed=changed)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/ceph_orch.py
+++ b/library/ceph_orch.py
@@ -1,0 +1,53 @@
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+# Author: Guillaume Abrioux <gabrioux@redhat.com>
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule  # type: ignore
+try:
+    from ansible.module_utils.ceph_common import exit_module, build_cmd  # type: ignore
+except ImportError:
+    from module_utils.ceph_common import exit_module, build_cmd  # type: ignore
+
+import datetime
+
+
+def main() -> None:
+    module = AnsibleModule(
+        argument_spec=dict(
+            cli_binary=dict(type='bool', required=False, default=False),
+            command=dict(type='str', required=True),
+            stdin=dict(type='str', required=False, default=None),
+        ),
+        supports_check_mode=True,
+    )
+
+    # Gather module parameters in variables
+    cli_binary = module.params.get('cli_binary')
+    command = module.params.get('command')
+    stdin = module.params.get('stdin')
+
+    if module.check_mode:
+        module.exit_json(
+            changed=False,
+            stdout='',
+            stderr='',
+            rc=0,
+            start='',
+            end='',
+            delta='',
+        )
+
+    startd = datetime.datetime.now()
+
+    cmd = build_cmd(cli_binary, command)
+    rc, out, err = module.run_command(cmd, data=stdin)
+
+    exit_module(module=module, out=out, rc=rc,
+                cmd=cmd, err=err, startd=startd)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/ceph_orch.py
+++ b/library/ceph_orch.py
@@ -13,6 +13,57 @@ except ImportError:
 
 import datetime
 
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: ceph_orch
+short_description: Ansible cephadm/orch wrapper
+version_added: "2.10"
+description:
+    - Run Ceph commands through Ansible
+options:
+    cli_binary:
+        description:
+            - Run a `cephadm` command from the binary.
+              See cephadm --help
+        required: false
+        default: false
+    command:
+        description:
+            - The command to be executed.
+        required: true
+    stdin:
+        description:
+            - data to be passed to stdin
+        required: false
+
+author:
+    - Guillaume Abrioux <gabrioux@redhat.com>
+'''
+
+EXAMPLES = '''
+- name: bootstrap initial cluster
+  ceph_orch:
+    cli_binary: true
+    command: "cephadm bootstrap --fsid 3c9ba63a-c7df-4476-a1e7-317dfc711f82 --mon-ip 1.2.3.4 --skip-pull"
+
+- name: get the cephadm ssh pub key
+  ceph_orch:
+    command: "cephadm get-pub-key"
+  register: pub_key
+
+- name: add a host
+  ceph_orch:
+    command: "orch host add ceph-node-01"
+'''
+
+RETURN = '''#  '''
+
 
 def main() -> None:
     module = AnsibleModule(

--- a/library/ceph_orch.py
+++ b/library/ceph_orch.py
@@ -27,6 +27,10 @@ version_added: "2.10"
 description:
     - Run Ceph commands through Ansible
 options:
+    fsid:
+        description:
+            - the fsid of the Ceph cluster to interact with.
+        required: false
     cli_binary:
         description:
             - Run a `cephadm` command from the binary.
@@ -71,6 +75,7 @@ def main() -> None:
             cli_binary=dict(type='bool', required=False, default=False),
             command=dict(type='str', required=True),
             stdin=dict(type='str', required=False, default=None),
+            fsid=dict(type='str', required=False)
         ),
         supports_check_mode=True,
     )
@@ -93,7 +98,7 @@ def main() -> None:
 
     startd = datetime.datetime.now()
 
-    cmd = build_cmd(cli_binary, command)
+    cmd = build_cmd(module, cli_binary, command)
     rc, out, err = module.run_command(cmd, data=stdin)
 
     exit_module(module=module, out=out, rc=rc,

--- a/library/ceph_orch_apply.py
+++ b/library/ceph_orch_apply.py
@@ -1,0 +1,151 @@
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+# Author: Guillaume Abrioux <gabrioux@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+from typing import TYPE_CHECKING, List, Tuple
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule  # type: ignore
+try:
+    from ansible.module_utils.ceph_common import exit_module  # type: ignore
+except ImportError:
+    from module_utils.ceph_common import exit_module
+import datetime
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: ceph_orch_apply
+short_description: apply service spec
+version_added: "2.9"
+description:
+    - apply a service spec
+options:
+    name:
+        description:
+            - name of the host
+        required: true
+    address:
+        description:
+            - address of the host
+        required: true when state is present
+    set_admin_label:
+        description:
+            - enforce '_admin' label on the host specified
+              in 'name'
+        required: false
+        default: false
+    labels:
+        description:
+            - list of labels to apply on the host
+        required: false
+        default: []
+    state:
+        description:
+            - if set to 'present', it will ensure the name specified
+              in 'name' will be present.
+            - if set to 'present', it will remove the host specified in
+              'name'.
+            - if set to 'drain', it will schedule to remove all daemons
+              from the host specified in 'name'.
+        required: false
+        default: present
+author:
+    - Guillaume Abrioux <gabrioux@redhat.com>
+'''
+
+EXAMPLES = '''
+- name: apply osd spec
+    ceph_orch_apply:
+    spec: |
+        service_type: osd
+        service_id: osd
+        placement:
+        label: osds
+        spec:
+        data_devices:
+            all: true
+'''
+
+
+def build_base_cmd(module: "AnsibleModule") -> List[str]:
+    cmd = ['cephadm']
+    if module.params.get('docker'):
+        cmd.append('--docker')
+    cmd.extend(['shell', 'ceph', 'orch'])
+    return cmd
+
+
+def apply_spec(module: "AnsibleModule",
+               data: str) -> Tuple[int, List[str], str, str]:
+    cmd = build_base_cmd(module)
+    cmd.extend(['apply', '-i', '-'])
+    rc, out, err = module.run_command(cmd, data=data)
+
+    if rc:
+        raise RuntimeError(err)
+
+    return rc, cmd, out, err
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            spec=dict(type='str', required=True),
+            docker=dict(type=bool,
+                        required=False,
+                        default=False)
+        ),
+    )
+
+    spec = module.params.get('spec')
+
+    startd = datetime.datetime.now()
+    changed = False
+
+    rc, cmd, out, err = apply_spec(module, spec)
+    changed = True
+
+    if module.check_mode:
+        exit_module(
+            module=module,
+            out='',
+            rc=0,
+            cmd=cmd,
+            err='',
+            startd=startd,
+            changed=False
+        )
+    else:
+        exit_module(
+            module=module,
+            out=out,
+            rc=rc,
+            cmd=cmd,
+            err=err,
+            startd=startd,
+            changed=changed
+        )
+
+
+if __name__ == '__main__':
+    main()

--- a/library/ceph_orch_apply.py
+++ b/library/ceph_orch_apply.py
@@ -40,6 +40,10 @@ version_added: "2.9"
 description:
     - apply a service spec
 options:
+    fsid:
+        description:
+            - the fsid of the Ceph cluster to interact with.
+        required: false
     spec:
         description:
             - The service spec to apply
@@ -77,6 +81,7 @@ def apply_spec(module: "AnsibleModule",
 def main():
     module = AnsibleModule(
         argument_spec=dict(
+            fsid=dict(type='str', required=False),
             spec=dict(type='str', required=True),
             docker=dict(type=bool,
                         required=False,

--- a/library/ceph_orch_apply.py
+++ b/library/ceph_orch_apply.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import, division, print_function
-from typing import TYPE_CHECKING, List, Tuple
+from typing import List, Tuple
 __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule  # type: ignore
@@ -40,35 +40,10 @@ version_added: "2.9"
 description:
     - apply a service spec
 options:
-    name:
+    spec:
         description:
-            - name of the host
+            - The service spec to apply
         required: true
-    address:
-        description:
-            - address of the host
-        required: true when state is present
-    set_admin_label:
-        description:
-            - enforce '_admin' label on the host specified
-              in 'name'
-        required: false
-        default: false
-    labels:
-        description:
-            - list of labels to apply on the host
-        required: false
-        default: []
-    state:
-        description:
-            - if set to 'present', it will ensure the name specified
-              in 'name' will be present.
-            - if set to 'present', it will remove the host specified in
-              'name'.
-            - if set to 'drain', it will schedule to remove all daemons
-              from the host specified in 'name'.
-        required: false
-        default: present
 author:
     - Guillaume Abrioux <gabrioux@redhat.com>
 '''

--- a/library/ceph_orch_apply.py
+++ b/library/ceph_orch_apply.py
@@ -20,9 +20,9 @@ __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule  # type: ignore
 try:
-    from ansible.module_utils.ceph_common import exit_module  # type: ignore
+    from ansible.module_utils.ceph_common import exit_module, build_base_cmd  # type: ignore
 except ImportError:
-    from module_utils.ceph_common import exit_module
+    from module_utils.ceph_common import exit_module, build_base_cmd
 import datetime
 
 
@@ -60,14 +60,6 @@ EXAMPLES = '''
         data_devices:
             all: true
 '''
-
-
-def build_base_cmd(module: "AnsibleModule") -> List[str]:
-    cmd = ['cephadm']
-    if module.params.get('docker'):
-        cmd.append('--docker')
-    cmd.extend(['shell', 'ceph', 'orch'])
-    return cmd
 
 
 def apply_spec(module: "AnsibleModule",

--- a/library/ceph_orch_apply.py
+++ b/library/ceph_orch_apply.py
@@ -87,6 +87,7 @@ def main():
                         required=False,
                         default=False)
         ),
+        supports_check_mode=True
     )
 
     spec = module.params.get('spec')
@@ -94,29 +95,29 @@ def main():
     startd = datetime.datetime.now()
     changed = False
 
-    rc, cmd, out, err = apply_spec(module, spec)
-    changed = True
-
     if module.check_mode:
         exit_module(
             module=module,
             out='',
             rc=0,
-            cmd=cmd,
+            cmd=[],
             err='',
             startd=startd,
             changed=False
         )
-    else:
-        exit_module(
-            module=module,
-            out=out,
-            rc=rc,
-            cmd=cmd,
-            err=err,
-            startd=startd,
-            changed=changed
-        )
+
+    rc, cmd, out, err = apply_spec(module, spec)
+    changed = True
+
+    exit_module(
+        module=module,
+        out=out,
+        rc=rc,
+        cmd=cmd,
+        err=err,
+        startd=startd,
+        changed=changed
+    )
 
 
 if __name__ == '__main__':

--- a/library/ceph_orch_daemon.py
+++ b/library/ceph_orch_daemon.py
@@ -130,6 +130,7 @@ def main() -> None:
         module.exit_json(
             changed=False,
             stdout='',
+            cmd=[],
             stderr='',
             rc=0,
             start='',

--- a/library/ceph_orch_daemon.py
+++ b/library/ceph_orch_daemon.py
@@ -29,6 +29,10 @@ version_added: "2.9"
 description:
     - Start, stop or restart ceph daemon
 options:
+    fsid:
+        description:
+            - the fsid of the Ceph cluster to interact with.
+        required: false
     state:
         description:
             - The desired state of the service specified in 'name'.
@@ -110,7 +114,8 @@ def main() -> None:
             daemon_type=dict(type='str', required=True),
             docker=dict(type=bool,
                         required=False,
-                        default=False)
+                        default=False),
+            fsid=dict(type='str', required=False)
         ),
         supports_check_mode=True,
     )

--- a/library/ceph_orch_daemon.py
+++ b/library/ceph_orch_daemon.py
@@ -1,0 +1,168 @@
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+# Author: Guillaume Abrioux <gabrioux@redhat.com>
+
+from __future__ import absolute_import, division, print_function
+from typing import List, Tuple
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule  # type: ignore
+try:
+    from ansible.module_utils.ceph_common import retry, exit_module, build_base_cmd, fatal  # type: ignore
+except ImportError:
+    from module_utils.ceph_common import retry, exit_module, build_base_cmd, fatal  # type: ignore
+
+import datetime
+import json
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: ceph_orch_daemon
+short_description: stop/start daemon
+version_added: "2.9"
+description:
+    - Start, stop or restart ceph daemon
+options:
+    state:
+        description:
+            - The desired state of the service specified in 'name'.
+              If 'started', it ensures the service is started.
+              If 'stopped', it ensures the service is stopped.
+              If 'restarted', it will restart the service.
+        required: True
+    service_id:
+        description:
+            - The id of the service.
+        required: true
+    service_type:
+        description:
+            - The type of the service.
+        required: true
+
+author:
+    - Guillaume Abrioux <gabrioux@redhat.com>
+'''
+
+EXAMPLES = '''
+- name: start osd.0
+  ceph_orch_daemon:
+    state: started
+    daemon_id: 0
+    daemon_type: osd
+
+- name: stop mon.ceph-node0
+  ceph_orch_daemon:
+    state: stopped
+    daemon_id: ceph-node0
+    daemon_type: mon
+'''
+
+RETURN = '''#  '''
+
+
+def get_current_state(module: "AnsibleModule",
+                      daemon_type: str,
+                      daemon_id: str) -> Tuple[int, List[str], str, str]:
+    cmd = build_base_cmd(module)
+    cmd.extend(['ps', '--daemon_type',
+                daemon_type, '--daemon_id',
+                daemon_id, '--format', 'json',
+                '--refresh'])
+    rc, out, err = module.run_command(cmd)
+
+    return rc, cmd, out, err
+
+
+def update_daemon_status(module: "AnsibleModule",
+                         action: str,
+                         daemon_name: str) -> Tuple[int, List[str], str, str]:
+    cmd = build_base_cmd(module)
+    cmd.extend(['daemon', action, daemon_name])
+    rc, out, err = module.run_command(cmd)
+
+    return rc, cmd, out, err
+
+
+@retry(RuntimeError)
+def validate_updated_status(module: "AnsibleModule",
+                            action: str,
+                            daemon_type: str,
+                            daemon_id: str) -> None:
+    rc, cmd, out, err = get_current_state(module, daemon_type, daemon_id)
+    expected_state = 1 if action == 'start' else 0
+    if not json.loads(out)[0]['status'] == expected_state:
+        raise RuntimeError("Status for {}.{} isn't reported as expected.".format(daemon_type, daemon_id))
+
+
+def main() -> None:
+    module = AnsibleModule(
+        argument_spec=dict(
+            state=dict(type='str',
+                       required=True,
+                       choices=['started', 'stopped', 'restarted']),
+            daemon_id=dict(type='str', required=True),
+            daemon_type=dict(type='str', required=True),
+            docker=dict(type=bool,
+                        required=False,
+                        default=False)
+        ),
+        supports_check_mode=True,
+    )
+
+    # Gather module parameters in variables
+    state = module.params.get('state')
+    daemon_id = module.params.get('daemon_id')
+    daemon_type = module.params.get('daemon_type')
+    daemon_name = "{}.{}".format(daemon_type, daemon_id)
+
+    if module.check_mode:
+        module.exit_json(
+            changed=False,
+            stdout='',
+            stderr='',
+            rc=0,
+            start='',
+            end='',
+            delta='',
+        )
+
+    startd = datetime.datetime.now()
+    changed = False
+
+    rc, cmd, out, err = get_current_state(module, daemon_type, daemon_id)
+
+    if rc:
+        fatal("Can't get current status of {}: {}".format(daemon_name, err), module)
+
+    is_running = json.loads(out)[0]['status'] == 1
+
+    current_state = 'started' if is_running else 'stopped'
+    action = 'start' if state == 'started' else 'stop'
+    if state == current_state:
+        out = "{} is already {}, skipping.".format(daemon_name, state)
+    else:
+        rc, cmd, out, err = update_daemon_status(module, action, daemon_name)
+        validate_updated_status(module, action, daemon_type, daemon_id)
+        changed = True
+
+    if state == 'restarted':
+        action = 'restart'
+        changed = True
+        rc, cmd, out, err = update_daemon_status(module, action, daemon_name)
+
+    if rc:
+        fatal("Can't {} {}: {}".format(action, daemon_name, err))
+
+    exit_module(module=module, out=out, rc=rc,
+                cmd=cmd, err=err, startd=startd,
+                changed=changed)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/ceph_orch_host.py
+++ b/library/ceph_orch_host.py
@@ -64,7 +64,7 @@ options:
         description:
             - if set to 'present', it will ensure the name specified
               in 'name' will be present.
-            - if set to 'present', it will remove the host specified in
+            - if set to 'absent', it will remove the host specified in
               'name'.
             - if set to 'drain', it will schedule to remove all daemons
               from the host specified in 'name'.

--- a/library/ceph_orch_host.py
+++ b/library/ceph_orch_host.py
@@ -41,6 +41,10 @@ version_added: "2.9"
 description:
     - Add or remove hosts from ceph orchestration.
 options:
+    fsid:
+        description:
+            - the fsid of the Ceph cluster to interact with.
+        required: false
     name:
         description:
             - name of the host
@@ -154,7 +158,8 @@ def main() -> None:
                        default='present'),
             docker=dict(type=bool,
                         required=False,
-                        default=False)
+                        default=False),
+            fsid=dict(type='str', required=False)
         ),
         required_if=[['state', 'present', ['address']]]
     )

--- a/library/ceph_orch_host.py
+++ b/library/ceph_orch_host.py
@@ -20,9 +20,9 @@ __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule  # type: ignore
 try:
-    from ansible.module_utils.ceph_common import exit_module  # type: ignore
+    from ansible.module_utils.ceph_common import exit_module, build_base_cmd  # type: ignore
 except ImportError:
-    from module_utils.ceph_common import exit_module
+    from module_utils.ceph_common import exit_module, build_base_cmd
 import datetime
 import json
 
@@ -94,14 +94,6 @@ EXAMPLES = '''
     name: my-node-01
     state: absent
 '''
-
-
-def build_base_cmd(module: "AnsibleModule") -> List[str]:
-    cmd = ['cephadm']
-    if module.params.get('docker'):
-        cmd.append('--docker')
-    cmd.extend(['shell', 'ceph', 'orch'])
-    return cmd
 
 
 def get_current_state(module: "AnsibleModule") -> Tuple[int, List[str], str, str]:

--- a/library/ceph_orch_host.py
+++ b/library/ceph_orch_host.py
@@ -161,7 +161,8 @@ def main() -> None:
                         default=False),
             fsid=dict(type='str', required=False)
         ),
-        required_if=[['state', 'present', ['address']]]
+        required_if=[['state', 'present', ['address']]],
+        supports_check_mode=True
     )
 
     name = module.params.get('name')
@@ -174,6 +175,17 @@ def main() -> None:
     changed = False
 
     cmd = ['cephadm']
+
+    if module.check_mode:
+        exit_module(
+            module=module,
+            out='',
+            rc=0,
+            cmd=[],
+            err='',
+            startd=startd,
+            changed=False
+        )
 
     rc, cmd, out, err = get_current_state(module)
     current_state = json.loads(out)
@@ -223,26 +235,15 @@ def main() -> None:
             rc, cmd, out, err = update_host(module, state, name)
             changed = True
 
-    if module.check_mode:
-        exit_module(
-            module=module,
-            out='',
-            rc=0,
-            cmd=cmd,
-            err='',
-            startd=startd,
-            changed=False
-        )
-    else:
-        exit_module(
-            module=module,
-            out=out,
-            rc=rc,
-            cmd=cmd,
-            err=err,
-            startd=startd,
-            changed=changed
-        )
+    exit_module(
+        module=module,
+        out=out,
+        rc=rc,
+        cmd=cmd,
+        err=err,
+        startd=startd,
+        changed=changed
+    )
 
 
 if __name__ == '__main__':

--- a/library/ceph_orch_host.py
+++ b/library/ceph_orch_host.py
@@ -1,0 +1,252 @@
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+# Author: Guillaume Abrioux <gabrioux@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+from typing import List, Tuple
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule  # type: ignore
+try:
+    from ansible.module_utils.ceph_common import exit_module  # type: ignore
+except ImportError:
+    from module_utils.ceph_common import exit_module
+import datetime
+import json
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: ceph_orch_host
+short_description: add/remove hosts
+version_added: "2.9"
+description:
+    - Add or remove hosts from ceph orchestration.
+options:
+    name:
+        description:
+            - name of the host
+        required: true
+    address:
+        description:
+            - address of the host
+        required: true when state is present
+    set_admin_label:
+        description:
+            - enforce '_admin' label on the host specified
+              in 'name'
+        required: false
+        default: false
+    labels:
+        description:
+            - list of labels to apply on the host
+        required: false
+        default: []
+    state:
+        description:
+            - if set to 'present', it will ensure the name specified
+              in 'name' will be present.
+            - if set to 'present', it will remove the host specified in
+              'name'.
+            - if set to 'drain', it will schedule to remove all daemons
+              from the host specified in 'name'.
+        required: false
+        default: present
+author:
+    - Guillaume Abrioux <gabrioux@redhat.com>
+'''
+
+EXAMPLES = '''
+- name: add a host
+  ceph_orch_host:
+    name: my-node-01
+    address: 10.10.10.101
+
+- name: add a host
+  ceph_orch_host:
+    name: my-node-02
+    labels:
+      - mon
+      - mgr
+      - grp013
+    address: 10.10.10.102
+
+- name: remove a host
+  ceph_orch_host:
+    name: my-node-01
+    state: absent
+'''
+
+
+def build_base_cmd(module: "AnsibleModule") -> List[str]:
+    cmd = ['cephadm']
+    if module.params.get('docker'):
+        cmd.append('--docker')
+    cmd.extend(['shell', 'ceph', 'orch'])
+    return cmd
+
+
+def get_current_state(module: "AnsibleModule") -> Tuple[int, List[str], str, str]:
+    cmd = build_base_cmd(module)
+    cmd.extend(['host', 'ls', '--format', 'json'])
+    rc, out, err = module.run_command(cmd)
+
+    if rc:
+        raise RuntimeError(err)
+
+    return rc, cmd, out, err
+
+
+def update_label(module: "AnsibleModule",
+                 action: str,
+                 host: str,
+                 label: str = '') -> Tuple[int, List[str], str, str]:
+    cmd = build_base_cmd(module)
+    cmd.extend(['host', 'label', action,
+                host, label])
+    rc, out, err = module.run_command(cmd)
+
+    if rc:
+        raise RuntimeError(err)
+
+    return rc, cmd, out, err
+
+
+def update_host(module: "AnsibleModule",
+                action: str,
+                name: str,
+                address: str = '',
+                labels: List[str] = None) -> Tuple[int, List[str], str, str]:
+    cmd = build_base_cmd(module)
+    cmd.extend(['host', action, name])
+    if action == 'add':
+        cmd.append(address)
+    if labels:
+        cmd.extend(labels)
+    rc, out, err = module.run_command(cmd)
+
+    if rc:
+        raise RuntimeError(err)
+
+    return rc, cmd, out, err
+
+
+def main() -> None:
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(type='str', required=True),
+            address=dict(type='str', required=False),
+            set_admin_label=dict(type=bool, required=False, default=False),
+            labels=dict(type=list, required=False, default=[]),
+            state=dict(type='str',
+                       required=False,
+                       choices=['present', 'absent', 'drain'],
+                       default='present'),
+            docker=dict(type=bool,
+                        required=False,
+                        default=False)
+        ),
+        required_if=[['state', 'present', ['address']]]
+    )
+
+    name = module.params.get('name')
+    address = module.params.get('address')
+    set_admin_label = module.params.get('set_admin_label')
+    labels = module.params.get('labels')
+    state = module.params.get('state')
+
+    startd = datetime.datetime.now()
+    changed = False
+
+    cmd = ['cephadm']
+
+    rc, cmd, out, err = get_current_state(module)
+    current_state = json.loads(out)
+    current_names = [name['hostname'] for name in current_state]
+
+    if state == 'present':
+        if name in current_names:
+            current_state_host = [host for host in current_state if host['hostname'] == name][0]
+            if set_admin_label:
+                labels.append('_admin')
+            if labels:
+                differences = set(labels) ^ set(current_state_host['labels'])
+                if differences:
+                    _out = []
+                    for diff in differences:
+                        if diff in current_state_host['labels']:
+                            action = 'rm'
+                        else:
+                            action = 'add'
+                        rc, cmd, out, err = update_label(module, action, current_state_host['hostname'], diff)
+                        _out.append(out)
+                        if rc:
+                            exit_module(rc=rc,
+                                        startd=startd,
+                                        module=module,
+                                        cmd=cmd,
+                                        out=out,
+                                        err=err,
+                                        changed=False)
+                    exit_module(rc=rc,
+                                startd=startd,
+                                module=module,
+                                cmd=cmd,
+                                out=''.join(_out),
+                                err=err,
+                                changed=True)
+                out = '{} is already present, skipping.'.format(name)
+        else:
+            rc, cmd, out, err = update_host(module, 'add', name, address, labels)
+            if not rc:
+                changed = True
+
+    if state in ['absent', 'drain']:
+        if name not in current_names:
+            out = '{} is not present, skipping.'.format(name)
+        else:
+            rc, cmd, out, err = update_host(module, state, name)
+            changed = True
+
+    if module.check_mode:
+        exit_module(
+            module=module,
+            out='',
+            rc=0,
+            cmd=cmd,
+            err='',
+            startd=startd,
+            changed=False
+        )
+    else:
+        exit_module(
+            module=module,
+            out=out,
+            rc=rc,
+            cmd=cmd,
+            err=err,
+            startd=startd,
+            changed=changed
+        )
+
+
+if __name__ == '__main__':
+    main()

--- a/library/cephadm_bootstrap.py
+++ b/library/cephadm_bootstrap.py
@@ -22,7 +22,7 @@ try:
 except ImportError:
     from module_utils.ceph_common import exit_module
 import datetime
-
+import os
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
@@ -193,6 +193,37 @@ def main() -> None:
     startd = datetime.datetime.now()
 
     cmd = ['cephadm']
+    data_dir = '/var/lib/ceph'
+    ceph_conf = 'ceph.conf'
+    ceph_keyring = 'ceph.client.admin.keyring'
+    ceph_pubkey = 'ceph.pub'
+
+    if fsid:
+        if os.path.exists(os.path.join(data_dir, fsid)):
+            out = 'A cluster with fsid {} is already deployed.'.format(fsid)
+            exit_module(
+                rc=0,
+                startd=startd,
+                module=module,
+                cmd=cmd,
+                out=out,
+                changed=False
+            )
+
+    for f in [ceph_conf,
+              ceph_keyring,
+              ceph_pubkey]:
+        if not allow_overwrite:
+            if os.path.exists(os.path.join(data_dir, f)):
+                out = '{} already exists, skipping.'
+                exit_module(
+                    rc=0,
+                    startd=startd,
+                    module=module,
+                    cmd=cmd,
+                    out=out,
+                    changed=False
+                )
 
     if docker:
         cmd.append('--docker')

--- a/library/cephadm_bootstrap.py
+++ b/library/cephadm_bootstrap.py
@@ -1,0 +1,266 @@
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule  # type: ignore
+try:
+    from ansible.module_utils.ceph_common import exit_module  # type: ignore
+except ImportError:
+    from module_utils.ceph_common import exit_module
+import datetime
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: cephadm_bootstrap
+short_description: Bootstrap a Ceph cluster via cephadm
+version_added: "2.8"
+description:
+    - Bootstrap a Ceph cluster via cephadm
+options:
+    mon_ip:
+        description:
+            - Ceph monitor IP address.
+        required: true
+    image:
+        description:
+            - Ceph container image.
+        required: false
+    docker:
+        description:
+            - Use docker instead of podman.
+        required: false
+    fsid:
+        description:
+            - Ceph FSID.
+        required: false
+    pull:
+        description:
+            - Pull the Ceph container image.
+        required: false
+        default: true
+    dashboard:
+        description:
+            - Deploy the Ceph dashboard.
+        required: false
+        default: true
+    dashboard_user:
+        description:
+            - Ceph dashboard user.
+        required: false
+    dashboard_password:
+        description:
+            - Ceph dashboard password.
+        required: false
+    monitoring:
+        description:
+            - Deploy the monitoring stack.
+        required: false
+        default: true
+    firewalld:
+        description:
+            - Manage firewall rules with firewalld.
+        required: false
+        default: true
+    allow_overwrite:
+        description:
+            - allow overwrite of existing –output-* config/keyring/ssh files.
+        required: false
+        default: false
+    registry_url:
+        description:
+            - URL for custom registry.
+        required: false
+    registry_username:
+        description:
+            - Username for custom registry.
+        required: false
+    registry_password:
+        description:
+            - Password for custom registry.
+        required: false
+    registry_json:
+        description:
+            - JSON file with custom registry login info (URL,
+              username, password).
+        required: false
+    ssh_user:
+        description:
+            - SSH user used for cephadm ssh to the hosts.
+        required: false
+    ssh_config:
+        description:
+            - SSH config file path for cephadm ssh client.
+        required: false
+author:
+    - Dimitri Savineau <dsavinea@redhat.com>
+'''
+
+EXAMPLES = '''
+- name: bootstrap a cluster via cephadm (with default values)
+  cephadm_bootstrap:
+    mon_ip: 192.168.42.1
+
+- name: bootstrap a cluster via cephadm (with custom values)
+  cephadm_bootstrap:
+    mon_ip: 192.168.42.1
+    fsid: 3c9ba63a-c7df-4476-a1e7-317dfc711f82
+    image: quay.ceph.io/ceph/daemon-base:latest-master-devel
+    dashboard: false
+    monitoring: false
+    firewalld: false
+
+- name: bootstrap a cluster via cephadm with custom image via env var
+  cephadm_bootstrap:
+    mon_ip: 192.168.42.1
+  environment:
+    CEPHADM_IMAGE: quay.ceph.io/ceph/daemon-base:latest-master-devel
+'''
+
+RETURN = '''#  '''
+
+
+def main() -> None:
+    module = AnsibleModule(
+        argument_spec=dict(
+            mon_ip=dict(type='str', required=True),
+            image=dict(type='str', required=False),
+            docker=dict(type='bool', required=False, default=False),
+            fsid=dict(type='str', required=False),
+            pull=dict(type='bool', required=False, default=True),
+            dashboard=dict(type='bool', required=False, default=True),
+            dashboard_user=dict(type='str', required=False),
+            dashboard_password=dict(type='str', required=False, no_log=True),
+            monitoring=dict(type='bool', required=False, default=True),
+            firewalld=dict(type='bool', required=False, default=True),
+            allow_overwrite=dict(type='bool', required=False, default=False),
+            registry_url=dict(type='str', require=False),
+            registry_username=dict(type='str', require=False),
+            registry_password=dict(type='str', require=False, no_log=True),
+            registry_json=dict(type='path', require=False),
+            ssh_user=dict(type='str', required=False),
+            ssh_config=dict(type='str', required=False),
+        ),
+        supports_check_mode=True,
+        mutually_exclusive=[
+            ('registry_json', 'registry_url'),
+            ('registry_json', 'registry_username'),
+            ('registry_json', 'registry_password'),
+        ],
+        required_together=[
+            ('registry_url', 'registry_username', 'registry_password')
+        ],
+    )
+
+    mon_ip = module.params.get('mon_ip')
+    docker = module.params.get('docker')
+    image = module.params.get('image')
+    fsid = module.params.get('fsid')
+    pull = module.params.get('pull')
+    dashboard = module.params.get('dashboard')
+    dashboard_user = module.params.get('dashboard_user')
+    dashboard_password = module.params.get('dashboard_password')
+    monitoring = module.params.get('monitoring')
+    firewalld = module.params.get('firewalld')
+    allow_overwrite = module.params.get('allow_overwrite')
+    registry_url = module.params.get('registry_url')
+    registry_username = module.params.get('registry_username')
+    registry_password = module.params.get('registry_password')
+    registry_json = module.params.get('registry_json')
+    ssh_user = module.params.get('ssh_user')
+    ssh_config = module.params.get('ssh_config')
+
+    startd = datetime.datetime.now()
+
+    cmd = ['cephadm']
+
+    if docker:
+        cmd.append('--docker')
+
+    if image:
+        cmd.extend(['--image', image])
+
+    cmd.extend(['bootstrap', '--mon-ip', mon_ip])
+
+    if fsid:
+        cmd.extend(['--fsid', fsid])
+
+    if not pull:
+        cmd.append('--skip-pull')
+
+    if dashboard:
+        if dashboard_user:
+            cmd.extend(['--initial-dashboard-user', dashboard_user])
+        if dashboard_password:
+            cmd.extend(['--initial-dashboard-password', dashboard_password])
+    else:
+        cmd.append('--skip-dashboard')
+
+    if not monitoring:
+        cmd.append('--skip-monitoring-stack')
+
+    if not firewalld:
+        cmd.append('--skip-firewalld')
+
+    if allow_overwrite:
+        cmd.append('--allow-overwrite')
+
+    if registry_url and registry_username and registry_password:
+        cmd.extend(['--registry-url', registry_url,
+                    '--registry-username', registry_username,
+                    '--registry-password', registry_password])
+
+    if registry_json:
+        cmd.extend(['--registry-json', registry_json])
+
+    if ssh_user:
+        cmd.extend(['--ssh-user', ssh_user])
+
+    if ssh_config:
+        cmd.extend(['--ssh-config', ssh_config])
+
+    if module.check_mode:
+        exit_module(
+            module=module,
+            out='',
+            rc=0,
+            cmd=cmd,
+            err='',
+            startd=startd,
+            changed=False
+        )
+    else:
+        rc, out, err = module.run_command(cmd)
+        exit_module(
+            module=module,
+            out=out,
+            rc=rc,
+            cmd=cmd,
+            err=err,
+            startd=startd,
+            changed=True
+        )
+
+
+if __name__ == '__main__':
+    main()

--- a/module_utils/ceph_common.py
+++ b/module_utils/ceph_common.py
@@ -23,13 +23,18 @@ def retry(exceptions, retries=20, delay=1):
     return decorator
 
 
-def build_cmd(cli_binary: bool,
+def build_cmd(module: "AnsibleModule",
+              cli_binary: bool,
               cmd: str) -> List[str]:
 
     _cmd = []
+    fsid = module.params.get('fsid')
 
     if not cli_binary:
-        _cmd.extend(['cephadm', 'shell', 'ceph'])
+        _cmd.extend(['cephadm', 'shell'])
+        if fsid:
+            _cmd.extend(['--fsid', fsid])
+        _cmd.append('ceph')
 
     _cmd.extend(cmd.split(' '))
 
@@ -38,9 +43,15 @@ def build_cmd(cli_binary: bool,
 
 def build_base_cmd(module: "AnsibleModule"):
     cmd = ['cephadm']
+    fsid = module.params.get('fsid')
+
     if module.params.get('docker'):
         cmd.append('--docker')
-    cmd.extend(['shell', 'ceph', 'orch'])
+    cmd.append('shell')
+    if fsid:
+        cmd.extend(['--fsid', fsid])
+    cmd.extend(['ceph', 'orch'])
+
     return cmd
 
 

--- a/module_utils/ceph_common.py
+++ b/module_utils/ceph_common.py
@@ -19,8 +19,10 @@ def build_cmd(cli_binary: bool,
 
 
 def exit_module(module: "AnsibleModule",
-                out: str, rc: int, cmd: List[str],
-                err: str, startd: datetime.datetime,
+                rc: int, cmd: List[str],
+                startd: datetime.datetime,
+                out: str = '',
+                err: str = '',
                 changed: bool = False,
                 diff: Dict[str, str] = dict(before="", after="")) -> None:
     endd = datetime.datetime.now()

--- a/module_utils/ceph_common.py
+++ b/module_utils/ceph_common.py
@@ -1,0 +1,51 @@
+import datetime
+from typing import TYPE_CHECKING, List, Dict
+
+if TYPE_CHECKING:
+    from ansible.module_utils.basic import AnsibleModule  # type: ignore
+
+
+def build_cmd(cli_binary: bool,
+              cmd: str) -> List[str]:
+
+    _cmd = []
+
+    if not cli_binary:
+        _cmd.extend(['cephadm', 'shell', 'ceph'])
+
+    _cmd.extend(cmd.split(' '))
+
+    return _cmd
+
+
+def exit_module(module: "AnsibleModule",
+                out: str, rc: int, cmd: List[str],
+                err: str, startd: datetime.datetime,
+                changed: bool = False,
+                diff: Dict[str, str] = dict(before="", after="")) -> None:
+    endd = datetime.datetime.now()
+    delta = endd - startd
+
+    result = dict(
+        cmd=cmd,
+        start=str(startd),
+        end=str(endd),
+        delta=str(delta),
+        rc=rc,
+        stdout=out.rstrip("\r\n"),
+        stderr=err.rstrip("\r\n"),
+        changed=changed,
+        diff=diff
+    )
+    module.exit_json(**result)
+
+
+def fatal(message: str, module: "AnsibleModule") -> None:
+    '''
+    Report a fatal error and exit
+    '''
+
+    if module:
+        module.fail_json(msg=message, rc=1)
+    else:
+        raise(Exception(message))

--- a/module_utils/ceph_common.py
+++ b/module_utils/ceph_common.py
@@ -1,8 +1,26 @@
 import datetime
+import time
 from typing import TYPE_CHECKING, List, Dict
 
 if TYPE_CHECKING:
     from ansible.module_utils.basic import AnsibleModule  # type: ignore
+
+
+def retry(exceptions, retries=20, delay=1):
+    def decorator(f):
+        def _retry(*args, **kwargs):
+            _tries = retries
+            while _tries > 1:
+                try:
+                    print("{}".format(_tries))
+                    return f(*args, **kwargs)
+                except exceptions:
+                    time.sleep(delay)
+                    _tries -= 1
+            print("{} has failed after {} tries".format(f, retries))
+            return f(*args, **kwargs)
+        return _retry
+    return decorator
 
 
 def build_cmd(cli_binary: bool,

--- a/module_utils/ceph_common.py
+++ b/module_utils/ceph_common.py
@@ -18,6 +18,14 @@ def build_cmd(cli_binary: bool,
     return _cmd
 
 
+def build_base_cmd(module: "AnsibleModule"):
+    cmd = ['cephadm']
+    if module.params.get('docker'):
+        cmd.append('--docker')
+    cmd.extend(['shell', 'ceph', 'orch'])
+    return cmd
+
+
 def exit_module(module: "AnsibleModule",
                 rc: int, cmd: List[str],
                 startd: datetime.datetime,

--- a/module_utils/ceph_common.py
+++ b/module_utils/ceph_common.py
@@ -23,6 +23,17 @@ def retry(exceptions, retries=20, delay=1):
     return decorator
 
 
+def build_base_cmd_sh(module: "AnsibleModule") -> List[str]:
+
+    cmd = ['cephadm', 'shell']
+
+    fsid = module.params.get('fsid')
+    if fsid:
+        cmd.extend(['--fsid', fsid])
+
+    return cmd
+
+
 def build_cmd(module: "AnsibleModule",
               cli_binary: bool,
               cmd: str) -> List[str]:

--- a/tests/functional/Vagrantfile
+++ b/tests/functional/Vagrantfile
@@ -25,7 +25,7 @@ ansible_provision = proc do |ansible|
 end
 
 Vagrant.configure('2') do |config|
-  config.vm.box =  BOX || 'centos/8'
+  config.vm.box =  BOX
   config.ssh.insert_key = false # workaround for https://github.com/mitchellh/vagrant/issues/5048
 #  config.ssh.private_key_path = settings['ssh_private_key_path']
   config.ssh.username = 'vagrant'

--- a/tests/functional/ansible.cfg
+++ b/tests/functional/ansible.cfg
@@ -1,6 +1,8 @@
 [defaults]
 log_path = $HOME/ansible/ansible.log
 roles_path = ../../
+library = ../../library
+module_utils = ../../module_utils
 host_key_checking = False
 gathering = smart
 fact_caching = memory

--- a/tests/functional/deploy-cluster.yml
+++ b/tests/functional/deploy-cluster.yml
@@ -101,8 +101,12 @@
         name: ceph_defaults
 
     - name: update the placement of monitor hosts
-      ceph_orch:
-        command: "orch apply mon --placement=label:mons"
+      ceph_orch_apply:
+        spec: |
+          service_type: mon
+          service_id: mon
+          placement:
+            label: mons
 
     - name: waiting for the monitor to join the quorum...
       ceph_orch:
@@ -118,9 +122,8 @@
         command: "orch apply mgr --placement=label:mgrs"
 
     - name: update the placement of osd hosts
-      ceph_orch:
-        command: "orch apply osd -i -"
-        stdin: |
+      ceph_orch_apply:
+        spec: |
           service_type: osd
           service_id: osd
           placement:
@@ -128,12 +131,14 @@
           spec:
             data_devices:
               all: true
-      changed_when: false
 
     - name: update the placement of crash hosts
-      ceph_orch:
-        command: "orch apply crash --placement=label:ceph"
-      changed_when: false
+      ceph_orch_apply:
+        spec: |
+          service_type: crash
+          service_id: crash
+          placement:
+            host_pattern: '*'
 
     - name: enable the monitoring
       ceph_orch:

--- a/tests/functional/deploy-cluster.yml
+++ b/tests/functional/deploy-cluster.yml
@@ -47,11 +47,6 @@
     - import_role:
         name: ceph_defaults
 
-    - name: create /etc/ceph directory
-      file:
-        path: /etc/ceph
-        state: directory
-
     - name: bootstrap initial cluster
       cephadm_bootstrap:
         mon_ip: "{{ monitor_address }}"

--- a/tests/functional/deploy-cluster.yml
+++ b/tests/functional/deploy-cluster.yml
@@ -83,22 +83,14 @@
         command: cephadm prepare-host
       changed_when: false
 
-    - name: manage nodes with cephadm
-      ceph_orch:
-        command: "orch host add {{ ansible_facts['hostname'] }} {{ ansible_facts['default_ipv4']['address'] }} {{ group_names | join(' ') }} {{ '_admin monitoring' if inventory_hostname == 'ceph-node0' else '' }}"
-      changed_when: false
+    - name: add hosts
+      ceph_orch_host:
+        name: "{{ ansible_facts['hostname'] }}"
+        address: "{{ ansible_facts['default_ipv4']['address'] }}"
+        set_admin_label: "{{ True if inventory_hostname in groups.get('admin', []) else omit }}"
+        labels: "{{ labels }}"
       delegate_to: "{{ groups['mons'][0] }}"
 
-    - name: add ceph label for core component
-      ceph_orch:
-        command: "orch host label add {{ ansible_facts['hostname'] }} ceph"
-      delegate_to: "{{ groups['mons'][0] }}"
-      when: inventory_hostname in groups.get('mons', []) or
-            inventory_hostname in groups.get('osds', []) or
-            inventory_hostname in groups.get('mdss', []) or
-            inventory_hostname in groups.get('rgws', []) or
-            inventory_hostname in groups.get('mgrs', []) or
-            inventory_hostname in groups.get('rbdmirrors', [])
 
 - name: adjust service placement
   hosts: "{{ groups.get('mons')[0] }}"

--- a/tests/functional/deploy-cluster.yml
+++ b/tests/functional/deploy-cluster.yml
@@ -28,30 +28,10 @@
       run_once: true
       when: delegate_facts_host | bool
 
-    - name: check if podman binary is present
-      stat:
-        path: /usr/bin/podman
-      register: podman_binary
-
-    - name: set_fact container_binary
-      set_fact:
-        container_binary: "{{ 'podman' if (podman_binary.stat.exists and ansible_facts['distribution'] == 'Fedora') or (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] == '8') else 'docker' }}"
-
-    - name: check if it is atomic host
-      stat:
-        path: /run/ostree-booted
-      register: stat_ostree
-
-    - name: set_fact is_atomic
-      set_fact:
-        is_atomic: "{{ stat_ostree.stat.exists }}"
-
-    - name: set_fact cephadm_cmd
-      set_fact:
-        cephadm_cmd: "cephadm {{ '--docker' if container_binary == 'docker' else '' }}"
-
     - name: container registry authentication
-      command: "{{ cephadm_cmd }} registry-login --registry-url {{ ceph_container_registry }} --registry-username {{ ceph_container_registry_username }} --registry-password {{ ceph_container_registry_password }}"
+      ceph_orch:
+        cli_binary: true
+        command: "cephadm registry-login --registry-url {{ ceph_container_registry }} --registry-username {{ ceph_container_registry_username }} --registry-password {{ ceph_container_registry_password }}"
       changed_when: false
       environment:
         HTTP_PROXY: "{{ ceph_container_http_proxy | default('') }}"
@@ -90,7 +70,8 @@
         name: ceph_defaults
 
     - name: get the cephadm ssh pub key
-      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} cephadm get-pub-key"
+      ceph_orch:
+        command: "cephadm get-pub-key"
       changed_when: false
       run_once: true
       register: cephadm_pubpkey
@@ -102,17 +83,20 @@
         key: '{{ cephadm_pubpkey.stdout }}'
 
     - name: run cephadm prepare-host
-      command: cephadm prepare-host
+      ceph_orch:
+        cli_binary: true
+        command: cephadm prepare-host
       changed_when: false
 
     - name: manage nodes with cephadm
-      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch host add {{ ansible_facts['hostname'] }} {{ ansible_facts['default_ipv4']['address'] }} {{ group_names | join(' ') }} {{ '_admin' if inventory_hostname == 'ceph-node0' else '' }}"
+      ceph_orch:
+        command: "orch host add {{ ansible_facts['hostname'] }} {{ ansible_facts['default_ipv4']['address'] }} {{ group_names | join(' ') }} {{ '_admin monitoring' if inventory_hostname == 'ceph-node0' else '' }}"
       changed_when: false
       delegate_to: "{{ groups['mons'][0] }}"
 
     - name: add ceph label for core component
-      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch host label add {{ ansible_facts['hostname'] }} ceph"
-      changed_when: false
+      ceph_orch:
+        command: "orch host label add {{ ansible_facts['hostname'] }} ceph"
       delegate_to: "{{ groups['mons'][0] }}"
       when: inventory_hostname in groups.get('mons', []) or
             inventory_hostname in groups.get('osds', []) or
@@ -130,24 +114,25 @@
         name: ceph_defaults
 
     - name: update the placement of monitor hosts
-      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch apply mon --placement='label:mons'"
-      changed_when: false
+      ceph_orch:
+        command: "orch apply mon --placement=label:mons"
 
     - name: waiting for the monitor to join the quorum...
-      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} quorum_status --format json"
-      changed_when: false
+      ceph_orch:
+        command: "quorum_status --format json"
       register: ceph_health_raw
+      changed_when: false
       until: (ceph_health_raw.stdout | from_json)["quorum_names"] | length == groups.get('mons', []) | length
       retries: "{{ health_mon_check_retries }}"
       delay: "{{ health_mon_check_delay }}"
 
     - name: update the placement of manager hosts
-      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch apply mgr --placement='label:mgrs'"
-      changed_when: false
+      ceph_orch:
+        command: "orch apply mgr --placement=label:mgrs"
 
     - name: update the placement of osd hosts
-      shell: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch apply osd -i -"
-      args:
+      ceph_orch:
+        command: "orch apply osd -i -"
         stdin: |
           service_type: osd
           service_id: osd
@@ -159,53 +144,27 @@
       changed_when: false
 
     - name: update the placement of crash hosts
-      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch apply crash --placement='label:ceph'"
+      ceph_orch:
+        command: "orch apply crash --placement=label:ceph"
       changed_when: false
 
-- name: adjust monitoring service placement
-  hosts: "monitoring"
-  become: true
-  gather_facts: false
-  tasks:
-    - import_role:
-        name: ceph_defaults
-
-    - name: dashboard related tasks
-      delegate_to: "{{ groups['mons'][0] }}"
-      run_once: true
-      block:
-        - name: enable the prometheus module
-          command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} mgr module enable prometheus"
-          changed_when: false
-
-        - name: update the placement of alertmanager hosts
-          command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch apply alertmanager --placement='label:monitoring'"
-          changed_when: false
-
-        - name: update the placement of grafana hosts
-          command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch apply grafana --placement='label:monitoring'"
-          changed_when: false
-
-        - name: update the placement of prometheus hosts
-          command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch apply prometheus --placement='label:monitoring'"
-          changed_when: false
-
-        - name: update the placement of node-exporter hosts
-          command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch apply node-exporter --placement='*'"
-          changed_when: false
-
-- name: print information
-  hosts: "{{ groups.get('mons')[0] }}"
-  become: true
-  gather_facts: false
-  tasks:
-    - import_role:
-        name: ceph_defaults
-
-    - name: show ceph orchestrator services
-      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch ls --refresh"
+    - name: enable the monitoring
+      ceph_orch:
+        command: "{{ item }}"
       changed_when: false
+      loop:
+        - "mgr module enable prometheus"
+        - "orch apply alertmanager --placement=label:monitoring"
+        - "orch apply grafana --placement=label:monitoring"
+        - "orch apply prometheus --placement=label:monitoring"
+        - "orch apply node-exporter --placement=*"
 
-    - name: show ceph orchestrator daemons
-      command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch ps --refresh"
-      changed_when: false
+
+# TODO(guits): address the following tasks:
+    # - name: show ceph orchestrator services
+    #   command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch ls --refresh"
+    #   changed_when: false
+
+    # - name: show ceph orchestrator daemons
+    #   command: "{{ cephadm_cmd }} shell -- ceph --cluster {{ cluster }} orch ps --refresh"
+    #   changed_when: false

--- a/tests/functional/deploy-cluster.yml
+++ b/tests/functional/deploy-cluster.yml
@@ -73,8 +73,10 @@
         state: directory
 
     - name: bootstrap initial cluster
-      command: "{{ cephadm_cmd }} bootstrap --mon-ip {{ monitor_address }} --skip-pull --skip-dashboard --skip-monitoring-stack {{ '--fsid ' + fsid if fsid is defined else '' }}"
-
+      cephadm_bootstrap:
+        mon_ip: "{{ monitor_address }}"
+        fsid: "{{ fsid if fsid is defined else omit }}"
+        pull: false
 
 - name: add the other nodes
   hosts:

--- a/tests/functional/hosts
+++ b/tests/functional/hosts
@@ -1,10 +1,10 @@
 [ceph_cluster]
-ceph-node0
-ceph-node1
-ceph-node2
-ceph-node3
-ceph-node4
-ceph-node5
+ceph-node0 labels="['mons', 'mgrs', 'monitoring']"
+ceph-node1 labels="['mons', 'mgrs']"
+ceph-node2 labels="['mons', 'mgrs']"
+ceph-node3 labels="['rgws']"
+ceph-node4 labels="['osds']"
+ceph-node5 labels="['iscsigws']"
 
 [admin]
 ceph-node0

--- a/tests/functional/tests/test_clients.py
+++ b/tests/functional/tests/test_clients.py
@@ -11,3 +11,11 @@ class TestClients(object):
     def test_ceph_keyring(self, node, host):
         assert host.file('/etc/ceph/ceph.keyring').exists
         assert host.file('/etc/ceph/ceph.keyring').mode == 0o600
+
+    @pytest.mark.client
+    def test_ceph_common_package_is_installed(self, node, host):
+        assert host.package("ceph-common").is_installed
+
+    @pytest.mark.client
+    def test_chrony_package_is_installed(self, node, host):
+        assert host.package("chrony").is_installed

--- a/tests/library/common.py
+++ b/tests/library/common.py
@@ -1,0 +1,29 @@
+from ansible.module_utils import basic
+from ansible.module_utils._text import to_bytes
+import json
+
+
+def set_module_args(args):
+    if '_ansible_remote_tmp' not in args:
+        args['_ansible_remote_tmp'] = '/tmp'
+    if '_ansible_keep_remote_files' not in args:
+        args['_ansible_keep_remote_files'] = False
+
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)
+
+
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def exit_json(*args, **kwargs):
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    raise AnsibleFailJson(kwargs)

--- a/tests/library/test_cephadm_bootstrap.py
+++ b/tests/library/test_cephadm_bootstrap.py
@@ -1,0 +1,304 @@
+from mock.mock import patch
+import pytest
+import common
+import cephadm_bootstrap
+
+fake_fsid = '0f1e0605-db0b-485c-b366-bd8abaa83f3b'
+fake_image = 'quay.ceph.io/ceph/daemon-base:latest-master-devel'
+fake_ip = '192.168.42.1'
+fake_registry = 'quay.ceph.io'
+fake_registry_user = 'foo'
+fake_registry_pass = 'bar'
+fake_registry_json = 'registry.json'
+
+
+class TestCephadmBootstrapModule(object):
+
+    @patch('ansible.module_utils.basic.AnsibleModule.fail_json')
+    def test_without_parameters(self, m_fail_json):
+        common.set_module_args({})
+        m_fail_json.side_effect = common.fail_json
+
+        with pytest.raises(common.AnsibleFailJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert result['msg'] == 'missing required arguments: mon_ip'
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    def test_with_check_mode(self, m_exit_json):
+        common.set_module_args({
+            'mon_ip': fake_ip,
+            '_ansible_check_mode': True
+        })
+        m_exit_json.side_effect = common.exit_json
+
+        with pytest.raises(common.AnsibleExitJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert not result['changed']
+        assert result['cmd'] == ['cephadm', 'bootstrap', '--mon-ip', fake_ip]
+        assert result['rc'] == 0
+        assert not result['stdout']
+        assert not result['stderr']
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_with_failure(self, m_run_command, m_exit_json):
+        common.set_module_args({
+            'mon_ip': fake_ip
+        })
+        m_exit_json.side_effect = common.exit_json
+        stdout = ''
+        stderr = 'ERROR: cephadm should be run as root'
+        rc = 1
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(common.AnsibleExitJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', 'bootstrap', '--mon-ip', fake_ip]
+        assert result['rc'] == 1
+        assert result['stderr'] == 'ERROR: cephadm should be run as root'
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_with_default_values(self, m_run_command, m_exit_json):
+        common.set_module_args({
+            'mon_ip': fake_ip
+        })
+        m_exit_json.side_effect = common.exit_json
+        stdout = 'Bootstrap complete.'
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(common.AnsibleExitJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', 'bootstrap', '--mon-ip', fake_ip]
+        assert result['rc'] == 0
+        assert result['stdout'] == 'Bootstrap complete.'
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_with_docker(self, m_run_command, m_exit_json):
+        common.set_module_args({
+            'mon_ip': fake_ip,
+            'docker': True
+        })
+        m_exit_json.side_effect = common.exit_json
+        stdout = ''
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(common.AnsibleExitJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', '--docker', 'bootstrap', '--mon-ip', fake_ip]
+        assert result['rc'] == 0
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_with_custom_image(self, m_run_command, m_exit_json):
+        common.set_module_args({
+            'mon_ip': fake_ip,
+            'image': fake_image
+        })
+        m_exit_json.side_effect = common.exit_json
+        stdout = ''
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(common.AnsibleExitJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', '--image', fake_image, 'bootstrap', '--mon-ip', fake_ip]
+        assert result['rc'] == 0
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_with_custom_fsid(self, m_run_command, m_exit_json):
+        common.set_module_args({
+            'mon_ip': fake_ip,
+            'fsid': fake_fsid
+        })
+        m_exit_json.side_effect = common.exit_json
+        stdout = ''
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(common.AnsibleExitJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', 'bootstrap', '--mon-ip', fake_ip, '--fsid', fake_fsid]
+        assert result['rc'] == 0
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_without_pull(self, m_run_command, m_exit_json):
+        common.set_module_args({
+            'mon_ip': fake_ip,
+            'pull': False
+        })
+        m_exit_json.side_effect = common.exit_json
+        stdout = ''
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(common.AnsibleExitJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', 'bootstrap', '--mon-ip', fake_ip, '--skip-pull']
+        assert result['rc'] == 0
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_with_dashboard_user_password(self, m_run_command, m_exit_json):
+        common.set_module_args({
+            'mon_ip': fake_ip,
+            'dashboard': True,
+            'dashboard_user': 'foo',
+            'dashboard_password': 'bar'
+        })
+        m_exit_json.side_effect = common.exit_json
+        stdout = ''
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(common.AnsibleExitJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', 'bootstrap', '--mon-ip', fake_ip, '--initial-dashboard-user', 'foo', '--initial-dashboard-password', 'bar']
+        assert result['rc'] == 0
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_without_dashboard(self, m_run_command, m_exit_json):
+        common.set_module_args({
+            'mon_ip': fake_ip,
+            'dashboard': False
+        })
+        m_exit_json.side_effect = common.exit_json
+        stdout = ''
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(common.AnsibleExitJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', 'bootstrap', '--mon-ip', fake_ip, '--skip-dashboard']
+        assert result['rc'] == 0
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_without_monitoring(self, m_run_command, m_exit_json):
+        common.set_module_args({
+            'mon_ip': fake_ip,
+            'monitoring': False
+        })
+        m_exit_json.side_effect = common.exit_json
+        stdout = ''
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(common.AnsibleExitJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', 'bootstrap', '--mon-ip', fake_ip, '--skip-monitoring-stack']
+        assert result['rc'] == 0
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_without_firewalld(self, m_run_command, m_exit_json):
+        common.set_module_args({
+            'mon_ip': fake_ip,
+            'firewalld': False
+        })
+        m_exit_json.side_effect = common.exit_json
+        stdout = ''
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(common.AnsibleExitJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', 'bootstrap', '--mon-ip', fake_ip, '--skip-firewalld']
+        assert result['rc'] == 0
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_with_registry_credentials(self, m_run_command, m_exit_json):
+        common.set_module_args({
+            'mon_ip': fake_ip,
+            'registry_url': fake_registry,
+            'registry_username': fake_registry_user,
+            'registry_password': fake_registry_pass
+        })
+        m_exit_json.side_effect = common.exit_json
+        stdout = ''
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(common.AnsibleExitJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', 'bootstrap', '--mon-ip', fake_ip,
+                                 '--registry-url', fake_registry,
+                                 '--registry-username', fake_registry_user,
+                                 '--registry-password', fake_registry_pass]
+        assert result['rc'] == 0
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_with_registry_json_file(self, m_run_command, m_exit_json):
+        common.set_module_args({
+            'mon_ip': fake_ip,
+            'registry_json': fake_registry_json
+        })
+        m_exit_json.side_effect = common.exit_json
+        stdout = ''
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(common.AnsibleExitJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', 'bootstrap', '--mon-ip', fake_ip,
+                                 '--registry-json', fake_registry_json]
+        assert result['rc'] == 0

--- a/tests/module_utils/test_ceph_common.py
+++ b/tests/module_utils/test_ceph_common.py
@@ -1,0 +1,44 @@
+import ceph_common
+import pytest
+from mock.mock import MagicMock
+
+
+class TestCephCommon(object):
+    def setup_method(self):
+        self.fake_module = MagicMock()
+        self.fake_params = {}
+        self.fake_module.params = self.fake_params
+
+    def test_build_base_cmd_sh_with_fsid(self):
+        expected_cmd = ['cephadm', 'shell', '--fsid', '123']
+        self.fake_module.params = {'fsid': '123'}
+        cmd = ceph_common.build_base_cmd_sh(self.fake_module)
+        assert cmd == expected_cmd
+
+    def test_build_base_cmd_sh_no_arg(self):
+        expected_cmd = ['cephadm', 'shell']
+        cmd = ceph_common.build_base_cmd_sh(self.fake_module)
+        assert cmd == expected_cmd
+
+    def test_build_base_cmd_no_arg(self):
+        expected_cmd = ['cephadm', 'shell', 'ceph', 'orch']
+        cmd = ceph_common.build_base_cmd(self.fake_module)
+        assert cmd == expected_cmd
+
+    def test_build_base_cmd_with_docker_arg(self):
+        expected_cmd = ['cephadm', '--docker', 'shell', 'ceph', 'orch']
+        self.fake_module.params = {'docker': True}
+        cmd = ceph_common.build_base_cmd(self.fake_module)
+        assert cmd == expected_cmd
+
+    def test_build_base_cmd_with_fsid_arg(self):
+        expected_cmd = ['cephadm', 'shell', '--fsid', '456', 'ceph', 'orch']
+        self.fake_module.params = {'fsid': '456'}
+        cmd = ceph_common.build_base_cmd(self.fake_module)
+        assert cmd == expected_cmd
+
+    def test_fatal(self):
+        ceph_common.fatal("error", self.fake_module)
+        self.fake_module.fail_json.assert_called_with(msg='error', rc=1)
+        with pytest.raises(Exception):
+            ceph_common.fatal("error", False)

--- a/tests/scripts/vagrant_up.sh
+++ b/tests/scripts/vagrant_up.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
-vagrant box remove centos/stream8 --all --force || true
-vagrant box add --name centos/stream8 https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-20220125.1.x86_64.vagrant-libvirt.box --force
+if [[ "${CEPH_ANSIBLE_VAGRANT_BOX}" =~ "centos/stream" ]]; then
+  EL_VERSION="${CEPH_ANSIBLE_VAGRANT_BOX: -1}"
+  LATEST_IMAGE="$(curl -s https://cloud.centos.org/centos/${EL_VERSION}-stream/x86_64/images/CHECKSUM | sed -nE 's/^SHA256.*\((.*-([0-9]+).*vagrant-libvirt.box)\).*$/\1/p' | sort -u | tail -n1)"
+  vagrant box remove "${CEPH_ANSIBLE_VAGRANT_BOX}" --all --force || true
+  vagrant box add --name "${CEPH_ANSIBLE_VAGRANT_BOX}" "https://cloud.centos.org/centos/${EL_VERSION}-stream/x86_64/images/${LATEST_IMAGE}" --force
+fi
 
 retries=0
 until [ $retries -ge 5 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
-envlist = flake8,mypy,functional
+envlist =
+  flake8,mypy
+  {el8,el9}-{functional}
 skipsdist = True
 
 [testenv:mypy]
@@ -14,7 +16,7 @@ deps =
     flake8
 commands = flake8 --max-line-length 160 {toxinidir}/library/ {toxinidir}/module_utils/
 
-[testenv:functional]
+[testenv:{el8,el9}-functional]
 whitelist_externals =
     vagrant
     bash
@@ -22,6 +24,9 @@ whitelist_externals =
 passenv=*
 sitepackages=True
 setenv=
+  # Set the vagrant box image to use
+  el8: CEPH_ANSIBLE_VAGRANT_BOX = centos/stream8
+  el9: CEPH_ANSIBLE_VAGRANT_BOX = centos/stream9
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config -o ControlMaster=auto -o ControlPersist=600s -o PreferredAuthentications=publickey
   ANSIBLE_CONFIG = {toxinidir}/ansible.cfg
   ANSIBLE_CALLBACK_WHITELIST = profile_tasks
@@ -30,8 +35,6 @@ setenv=
   ANSIBLE_GATHERING = implicit
   # only available for ansible >= 2.5
   ANSIBLE_STDOUT_CALLBACK = yaml
-  # Set the vagrant box image to use
-  CEPH_ANSIBLE_VAGRANT_BOX = centos/stream8
 
 deps= -r{toxinidir}/tests/requirements.txt
 changedir= {toxinidir}/tests/functional

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-  flake8,mypy
+  flake8,mypy,unittests
   {el8,el9}-{functional}
 skipsdist = True
 
@@ -14,7 +14,18 @@ commands = mypy {toxinidir}/library {toxinidir}/module_utils
 basepython = python3
 deps =
     flake8
-commands = flake8 --max-line-length 160 {toxinidir}/library/ {toxinidir}/module_utils/
+commands = flake8 --max-line-length 160 {toxinidir}/library/ {toxinidir}/module_utils/ {toxinidir}/tests/library/ {toxinidir}/tests/module_utils
+
+[testenv:unittests]
+basepython = python3
+deps =
+  pytest-xdist
+  pytest
+  mock
+  ansible
+setenv=
+  PYTHONPATH = {env:PYTHONPATH:}:{toxinidir}/library:{toxinidir}/module_utils:{toxinidir}/tests/library
+commands = py.test -vvv -n=auto {toxinidir}/tests/library/ {toxinidir}/tests/module_utils
 
 [testenv:{el8,el9}-functional]
 whitelist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+envlist = mypy,deploy_and_purge
 skipsdist = True
 
 [testenv:mypy]
@@ -7,7 +8,7 @@ deps =
     mypy
 commands = mypy {toxinidir}/library {toxinidir}/module_utils
 
-[testenv]
+[testenv:deploy_and_purge]
 whitelist_externals =
     vagrant
     bash

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,mypy,deploy_and_purge
+envlist = flake8,mypy,functional
 skipsdist = True
 
 [testenv:mypy]
@@ -14,7 +14,7 @@ deps =
     flake8
 commands = flake8 --max-line-length 160 {toxinidir}/library/ {toxinidir}/module_utils/
 
-[testenv:deploy_and_purge]
+[testenv:functional]
 whitelist_externals =
     vagrant
     bash

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = mypy,deploy_and_purge
+envlist = flake8,mypy,deploy_and_purge
 skipsdist = True
 
 [testenv:mypy]
@@ -7,6 +7,12 @@ basepython = python3
 deps =
     mypy
 commands = mypy {toxinidir}/library {toxinidir}/module_utils
+
+[testenv:flake8]
+basepython = python3
+deps =
+    flake8
+commands = flake8 --max-line-length 160 {toxinidir}/library/ {toxinidir}/module_utils/
 
 [testenv:deploy_and_purge]
 whitelist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,12 @@
 [tox]
 skipsdist = True
 
+[testenv:mypy]
+basepython = python3
+deps =
+    mypy
+commands = mypy {toxinidir}/library {toxinidir}/module_utils
+
 [testenv]
 whitelist_externals =
     vagrant


### PR DESCRIPTION
This adds various modules:

cephadm_bootstrap: for bootstrapping new clusters with cephadm,
ceph_config: for getting/setting ceph option,
ceph_orch_host: for adding/removing hosts,
ceph_orch_apply: for applying service spec,
ceph_orch_daemon: for starting/stopping services,
ceph_orch: intended to be used as an ansible wrapper in order to run any ceph orch commands via ansible playbooks.

