### PR TITLE
Revert "tests: use a specific sha1"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,6 @@ commands=
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/cephadm-preflight.yml --extra-vars "\
       ceph_origin=shaman \
       client_group=clients \
-      ceph_dev_sha1=7608a400c0b612cc51f2f2f8aff7b47292b9b951 \
   "
   py.test -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts --ssh-config={changedir}/vagrant_ssh_config {changedir}/tests/test_preflight.py
 


### PR DESCRIPTION
This reverts commit 6dc7a19efcfb22094596f5bed9b162dac527721f.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>