### PR TITLE
library/orch_daemon: display a better error message

### DIFF
--- a/library/ceph_orch_daemon.py
+++ b/library/ceph_orch_daemon.py
@@ -144,6 +144,8 @@ def main() -> None:
     rc, cmd, out, err = get_current_state(module, daemon_type, daemon_id)
 
     if rc or not json.loads(out):
+        if not err:
+            err = 'osd id {} not found'.format(daemon_id)
         fatal("Can't get current status of {}: {}".format(daemon_name, err), module)
 
     is_running = json.loads(out)[0]['status'] == 1


### PR DESCRIPTION
When the osd id isn't found, the current message thrown lacks detail
about it.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 7760b9dafc2a182cf20bfa73bb054314fe9182a6)