### PR TITLE
doc: add a note about cephadm-distribute-ssh-key

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -4,12 +4,12 @@ Introduction
 ------------
 
 cephadm-ansible is a collection of Ansible modules and playbooks to simplify
-workflows that are not covered by [cephadm]_. The following workflows are covered
-by three playbooks:
+workflows that are not covered by [cephadm]_. They are covered by the following playbooks:
 
 * cephadm-preflight.yml: Initial setup of hosts before bootstrapping the cluster
 * cephadm-clients.yml: Setting up client hosts
 * cephadm-purge-cluster.yml: Remove a Ceph cluster
+* cephadm-distribute-ssh-key.yml: Distribute a SSH public key to all hosts
 
 Additionnally, several ansible modules are provided in order to let people writing their own playbooks.
 


### PR DESCRIPTION
Add cephadm-distribute-ssh-key to the list of playbooks in
introduction section.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 402799eabac22a904b5f9b145e22d85987379e81)