### PR TITLE
library: add cephadm_registry_login module

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -425,6 +425,18 @@ ceph_orch_daemon
 ``service_type``
   The type of the service.
 
+cephadm_registry_login
+++++++++++++++++++++++
+
+``state``
+  Whether the module should log in to the registry or log out.
+``registry_url``
+  The container registry to log in or log out.
+``registry_username``
+  The username to log in to the container registry.
+``registry_password``
+  The corresponding password to be used with ``registry_username``.
+
 Samples
 =======
 
@@ -448,6 +460,13 @@ Bootstrap and add some hosts::
      become: true
      gather_facts: false
      tasks:
+       - name: login to quay.io registry
+         cephadm_registry_login:
+           state: login
+           registry_url: quay.io
+           registry_username: foo
+           registry_password: b4r
+
        - name: bootstrap initial cluster
          cephadm_bootstrap:
            mon_ip: "{{ monitor_address }}"

--- a/library/ceph_config.py
+++ b/library/ceph_config.py
@@ -8,9 +8,9 @@ __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule  # type: ignore
 try:
-    from ansible.module_utils.ceph_common import exit_module, build_base_cmd_sh  # type: ignore
+    from ansible.module_utils.ceph_common import exit_module, build_base_cmd_shell  # type: ignore
 except ImportError:
-    from module_utils.ceph_common import exit_module, build_base_cmd_sh  # type: ignore
+    from module_utils.ceph_common import exit_module, build_base_cmd_shell  # type: ignore
 
 import datetime
 
@@ -89,7 +89,7 @@ def get_or_set_option(module: "AnsibleModule",
                       who: str,
                       option: str,
                       value: str) -> Tuple[int, List[str], str, str]:
-    cmd = build_base_cmd_sh(module)
+    cmd = build_base_cmd_shell(module)
     cmd.extend(['ceph', 'config', 'get', who, option])
 
     rc, out, err = module.run_command(cmd)

--- a/library/ceph_orch_apply.py
+++ b/library/ceph_orch_apply.py
@@ -20,9 +20,9 @@ __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule  # type: ignore
 try:
-    from ansible.module_utils.ceph_common import exit_module, build_base_cmd  # type: ignore
+    from ansible.module_utils.ceph_common import exit_module, build_base_cmd_orch  # type: ignore
 except ImportError:
-    from module_utils.ceph_common import exit_module, build_base_cmd
+    from module_utils.ceph_common import exit_module, build_base_cmd_orch
 import datetime
 
 
@@ -72,7 +72,7 @@ EXAMPLES = '''
 
 def apply_spec(module: "AnsibleModule",
                data: str) -> Tuple[int, List[str], str, str]:
-    cmd = build_base_cmd(module)
+    cmd = build_base_cmd_orch(module)
     cmd.extend(['apply', '-i', '-'])
     rc, out, err = module.run_command(cmd, data=data)
 

--- a/library/ceph_orch_daemon.py
+++ b/library/ceph_orch_daemon.py
@@ -8,9 +8,9 @@ __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule  # type: ignore
 try:
-    from ansible.module_utils.ceph_common import retry, exit_module, build_base_cmd, fatal  # type: ignore
+    from ansible.module_utils.ceph_common import retry, exit_module, build_base_cmd_orch, fatal  # type: ignore
 except ImportError:
-    from module_utils.ceph_common import retry, exit_module, build_base_cmd, fatal  # type: ignore
+    from module_utils.ceph_common import retry, exit_module, build_base_cmd_orch, fatal  # type: ignore
 
 import datetime
 import json
@@ -77,7 +77,7 @@ RETURN = '''#  '''
 def get_current_state(module: "AnsibleModule",
                       daemon_type: str,
                       daemon_id: str) -> Tuple[int, List[str], str, str]:
-    cmd = build_base_cmd(module)
+    cmd = build_base_cmd_orch(module)
     cmd.extend(['ps', '--daemon_type',
                 daemon_type, '--daemon_id',
                 daemon_id, '--format', 'json',
@@ -90,7 +90,7 @@ def get_current_state(module: "AnsibleModule",
 def update_daemon_status(module: "AnsibleModule",
                          action: str,
                          daemon_name: str) -> Tuple[int, List[str], str, str]:
-    cmd = build_base_cmd(module)
+    cmd = build_base_cmd_orch(module)
     cmd.extend(['daemon', action, daemon_name])
     rc, out, err = module.run_command(cmd)
 

--- a/library/ceph_orch_host.py
+++ b/library/ceph_orch_host.py
@@ -20,9 +20,9 @@ __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule  # type: ignore
 try:
-    from ansible.module_utils.ceph_common import exit_module, build_base_cmd  # type: ignore
+    from ansible.module_utils.ceph_common import exit_module, build_base_cmd_orch  # type: ignore
 except ImportError:
-    from module_utils.ceph_common import exit_module, build_base_cmd
+    from module_utils.ceph_common import exit_module, build_base_cmd_orch
 import datetime
 import json
 
@@ -105,7 +105,7 @@ EXAMPLES = '''
 
 
 def get_current_state(module: "AnsibleModule") -> Tuple[int, List[str], str, str]:
-    cmd = build_base_cmd(module)
+    cmd = build_base_cmd_orch(module)
     cmd.extend(['host', 'ls', '--format', 'json'])
     rc, out, err = module.run_command(cmd)
 
@@ -119,7 +119,7 @@ def update_label(module: "AnsibleModule",
                  action: str,
                  host: str,
                  label: str = '') -> Tuple[int, List[str], str, str]:
-    cmd = build_base_cmd(module)
+    cmd = build_base_cmd_orch(module)
     cmd.extend(['host', 'label', action,
                 host, label])
     rc, out, err = module.run_command(cmd)
@@ -135,7 +135,7 @@ def update_host(module: "AnsibleModule",
                 name: str,
                 address: str = '',
                 labels: List[str] = None) -> Tuple[int, List[str], str, str]:
-    cmd = build_base_cmd(module)
+    cmd = build_base_cmd_orch(module)
     cmd.extend(['host', action, name])
     if action == 'add':
         cmd.append(address)

--- a/library/cephadm_registry_login.py
+++ b/library/cephadm_registry_login.py
@@ -1,0 +1,219 @@
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+# Author: Guillaume Abrioux <gabrioux@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule  # type: ignore
+from typing import List, Tuple
+try:
+    from ansible.module_utils.ceph_common import exit_module, build_base_cmd, fatal  # type: ignore
+except ImportError:
+    from module_utils.ceph_common import exit_module, build_base_cmd, fatal
+import datetime
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: cephadm_registry_login
+short_description: Log in to container registry
+version_added: "2.9"
+description:
+    - Call cephadm registry-login command for logging in to container registry
+options:
+    state:
+        description:
+            - log in or log out from the registry.
+        default: login
+        required: false
+    docker:
+        description:
+            - Use docker instead of podman.
+        required: false
+    registry_url:
+        description:
+            - The url of the registry
+        required: true
+    registry_username:
+        description:
+            - The username to log in
+        required: true when state is 'login'
+    registry_password:
+        description:
+            - The corresponding password to log in.
+        required: true when state is 'login'
+    registry_json:
+        description:
+            - The path to a json file. This file must be present on remote hosts
+              prior to running this task.
+              *not supported yet*.
+author:
+    - Guillaume Abrioux <gabrioux@redhat.com>
+'''
+
+EXAMPLES = '''
+- name: log in to quay.io registry
+  cephadm_registry_login:
+    registry_url: quay.io
+    registry_username: my_login
+    registry_password: my_password
+
+- name: log out from quay.io registry
+  cephadm_registry_login:
+    state: logout
+    registry_url: quay.io
+'''
+
+RETURN = '''#  '''
+
+
+def build_base_container_cmd(module: "AnsibleModule", action: str = 'login') -> List[str]:
+    docker = module.params.get('docker')
+    container_binary = 'podman'
+
+    if docker:
+        container_binary = 'docker'
+
+    cmd = [container_binary, action]
+
+    return cmd
+
+
+def is_logged(module: "AnsibleModule") -> bool:
+    registry_url = module.params.get('registry_url')
+    registry_username = module.params.get('registry_username')
+    cmd = build_base_container_cmd(module)
+
+    cmd.extend(['--get-login', registry_url])
+
+    rc, out, err = module.run_command(cmd)
+
+    if not rc and out.strip() == registry_username:
+        return True
+
+    return False
+
+
+def do_login_or_logout(module: "AnsibleModule", action: str = 'login') -> Tuple[int, List[str], str, str]:
+    registry_url = module.params.get('registry_url')
+    registry_username = module.params.get('registry_username')
+    registry_password = module.params.get('registry_password')
+
+    cmd = build_base_container_cmd(module, action)
+    if action == 'login':
+        cmd.extend(['--username', registry_username, '--password-stdin', registry_url])
+    else:
+        cmd.extend([registry_url])
+
+    rc, out, err = module.run_command(cmd, data=registry_password)
+
+    return rc, cmd, out, err
+
+
+def main() -> None:
+    module = AnsibleModule(
+        argument_spec=dict(
+            state=dict(type='str', required=False, default='login', choices=['login', 'logout']),
+            docker=dict(type=bool,
+                        required=False,
+                        default=False),
+            registry_url=dict(type='str', required=True),
+            registry_username=dict(type='str', required=False),
+            registry_password=dict(type='str', required=False, no_log=True),
+            registry_json=dict(type='str', required=False)
+        ),
+        supports_check_mode=True,
+        mutually_exclusive=[
+            ('registry_json', 'registry_url'),
+            ('registry_json', 'registry_username'),
+            ('registry_json', 'registry_password'),
+        ],
+        # Note: the following might be needed when registry_json will be implemented
+        # required_together=[
+        #     ('registry_url', 'registry_username', 'registry_password')
+        # ],
+        required_if=[
+            ['state', 'login', ['registry_username', 'registry_password']],
+            ['state', 'logout', ['registry_url']]
+        ]
+    )
+    startd = datetime.datetime.now()
+    changed = False
+    cmd = build_base_cmd(module)
+    cmd.append('registry-login')
+
+    state = module.params.get('state')
+    registry_url = module.params.get('registry_url')
+    registry_username = module.params.get('registry_username')
+    registry_json = module.params.get('registry_json')
+
+    if module.check_mode:
+        exit_module(
+            module=module,
+            out='',
+            rc=0,
+            cmd=[],
+            err='',
+            startd=startd,
+            changed=False
+        )
+    if registry_json:
+        fatal('This feature is not supported yet.', module)
+    current_status = is_logged(module)
+    action = None
+    skip_msg = {
+        'login': f'Already logged in to {registry_url} with {registry_username}.',
+        'logout': f'Already logged out from {registry_url}.'
+    }
+    action_msg = {
+         'login': f'Couldn\'t log in to {registry_url} with {registry_username}.',
+         'logout': f'Couldn\'t log out from {registry_url}.'
+    }
+
+    if state == 'login' and not current_status or state == 'logout' and current_status:
+        action = state
+    else:
+        out = skip_msg[state]
+        rc = 0
+        err = ''
+        cmd = []
+
+    if action:
+        rc, cmd, out, err = do_login_or_logout(module, action)
+        if rc:
+            msg = f'{action_msg[state]}\nCmd: {cmd}\nErr: {err}'
+            fatal(msg, module)
+        else:
+            changed = True
+
+    exit_module(
+        module=module,
+        out=out,
+        rc=rc,
+        cmd=cmd,
+        err=err,
+        startd=startd,
+        changed=changed
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/module_utils/ceph_common.py
+++ b/module_utils/ceph_common.py
@@ -34,7 +34,7 @@ def build_base_cmd_sh(module: "AnsibleModule") -> List[str]:
     return cmd
 
 
-def build_base_cmd(module: "AnsibleModule"):
+def build_base_cmd(module: "AnsibleModule") -> List[str]:
     cmd = ['cephadm']
     fsid = module.params.get('fsid')
 

--- a/module_utils/ceph_common.py
+++ b/module_utils/ceph_common.py
@@ -23,28 +23,33 @@ def retry(exceptions, retries=20, delay=1):
     return decorator
 
 
-def build_base_cmd_sh(module: "AnsibleModule") -> List[str]:
+def build_base_cmd(module: "AnsibleModule") -> List[str]:
+    cmd = ['cephadm']
+    docker = module.params.get('docker')
+    image = module.params.get('image')
 
-    cmd = ['cephadm', 'shell']
+    if docker:
+        cmd.append('--docker')
+    if image:
+        cmd.extend(['--image', image])
 
+    return cmd
+
+
+def build_base_cmd_shell(module: "AnsibleModule") -> List[str]:
+    cmd = build_base_cmd(module)
     fsid = module.params.get('fsid')
+
+    cmd.append('shell')
+
     if fsid:
         cmd.extend(['--fsid', fsid])
 
     return cmd
 
 
-def build_base_cmd(module: "AnsibleModule") -> List[str]:
-    cmd = ['cephadm']
-    fsid = module.params.get('fsid')
-
-    if module.params.get('docker'):
-        cmd.append('--docker')
-    if module.params.get('image'):
-        cmd.extend(['--image', module.params.get('image')])
-    cmd.append('shell')
-    if fsid:
-        cmd.extend(['--fsid', fsid])
+def build_base_cmd_orch(module: "AnsibleModule") -> List[str]:
+    cmd = build_base_cmd_shell(module)
     cmd.extend(['ceph', 'orch'])
 
     return cmd

--- a/tests/functional/deploy-cluster.yml
+++ b/tests/functional/deploy-cluster.yml
@@ -29,8 +29,10 @@
       when: delegate_facts_host | bool
 
     - name: container registry authentication
-      command: "cephadm registry-login --registry-url {{ ceph_container_registry }} --registry-username {{ ceph_container_registry_username }} --registry-password {{ ceph_container_registry_password }}"
-      changed_when: false
+      cephadm_registry_login:
+        registry_url: "{{ ceph_container_registry }}"
+        registry_username: "{{ ceph_container_registry_username }}"
+        registry_password: "{{ ceph_container_registry_password }}"
       environment:
         HTTP_PROXY: "{{ ceph_container_http_proxy | default('') }}"
         HTTPS_PROXY: "{{ ceph_container_https_proxy | default('') }}"

--- a/tests/module_utils/test_ceph_common.py
+++ b/tests/module_utils/test_ceph_common.py
@@ -9,32 +9,27 @@ class TestCephCommon(object):
         self.fake_params = {'foo': 'bar'}
         self.fake_module.params = self.fake_params
 
-    def test_build_base_cmd_with_fsid_arg(self):
+    def test_build_base_cmd_orch_with_fsid_arg(self):
         expected_cmd = ['cephadm', 'shell', '--fsid', '123', 'ceph', 'orch']
         self.fake_module.params = {'fsid': '123'}
-        cmd = ceph_common.build_base_cmd(self.fake_module)
+        cmd = ceph_common.build_base_cmd_orch(self.fake_module)
         assert cmd == expected_cmd
 
-    def test_build_base_cmd_with_image_arg(self):
+    def test_build_base_cmd_orch_with_image_arg(self):
         expected_cmd = ['cephadm', '--image', 'quay.io/ceph-ci/ceph:main', 'shell', 'ceph', 'orch']
         self.fake_module.params = {'image': 'quay.io/ceph-ci/ceph:main'}
-        cmd = ceph_common.build_base_cmd(self.fake_module)
+        cmd = ceph_common.build_base_cmd_orch(self.fake_module)
         assert cmd == expected_cmd
 
-    def test_build_base_cmd_with_docker_arg(self):
+    def test_build_base_cmd_orch_with_docker_arg(self):
         expected_cmd = ['cephadm', '--docker', 'shell', 'ceph', 'orch']
         self.fake_module.params = {'docker': True}
-        cmd = ceph_common.build_base_cmd(self.fake_module)
+        cmd = ceph_common.build_base_cmd_orch(self.fake_module)
         assert cmd == expected_cmd
 
-    def test_build_base_cmd_no_arg(self):
+    def test_build_base_cmd_orch_no_arg(self):
         expected_cmd = ['cephadm', 'shell', 'ceph', 'orch']
-        cmd = ceph_common.build_base_cmd(self.fake_module)
-        assert cmd == expected_cmd
-
-    def test_build_base_cmd_sh_no_arg(self):
-        expected_cmd = ['cephadm', 'shell']
-        cmd = ceph_common.build_base_cmd_sh(self.fake_module)
+        cmd = ceph_common.build_base_cmd_orch(self.fake_module)
         assert cmd == expected_cmd
 
     def test_fatal(self):


### PR DESCRIPTION
This adds a new module `cephadm_registry_login` to wrap
the cephadm command `cephadm registry-login`.
    
Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>