### PR TITLE
preflight: support multiple custom repositories

### DIFF
--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -26,12 +26,12 @@
       import_role:
         name: ceph_defaults
 
-    - name: fail when ceph_origin is custom with no repo url defined
+    - name: fail when ceph_origin is custom with no repository defined
       fail:
-        msg: "You must pass custom_repo_url when ceph_origin is 'custom'"
+        msg: "You must define 'ceph_custom_repositories' when ceph_origin is 'custom'"
       when:
         - ceph_origin == 'custom'
-        - custom_repo_url is undefined
+        - ceph_custom_repositories is undefined
 
     - name: redhat family of OS related tasks
       when: ansible_facts['distribution'] == 'CentOS' or ansible_facts['distribution'] == 'RedHat'
@@ -118,18 +118,19 @@
         - name: enable custom repo
           when: ceph_origin == 'custom'
           block:
-            - name: setup custom repository
+            - name: setup custom repositories
               yum_repository:
-                name: ceph_custom
-                description: Ceph custom repo
-                gpgcheck: "{{ 'yes' if custom_repo_gpgkey is defined else 'no' }}"
-                state: present
-                gpgkey: "{{ custom_repo_gpgkey | default(omit) }}"
-                baseurl: "{{ custom_repo_url }}"
-                file: ceph_custom
-                priority: '2'
+                name: "{{ item.name }}"
+                description: "{{ item.description }}"
+                state: "{{ item.state | default(omit) }}"
+                gpgcheck: "{{ item.gpgcheck | default(omit) }}"
+                gpgkey: "{{ item.gpgkey | default(omit) }}"
+                baseurl: "{{ item.baseurl }}"
+                file: "{{ item.ceph_custom | default(omit) }}"
+                priority: "{{ item.priority | default(omit) }}"
               register: result
               until: result is succeeded
+              loop: "{{ ceph_custom_repositories }}"
 
         - name: install epel-release
           when: ansible_facts['distribution'] == 'CentOS'

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -157,16 +157,69 @@ ceph_dev_sha1
 **default**
   "latest"
 
-custom_repo_url
-~~~~~~~~~~~~~~~
+ceph_custom_repositories
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+This variable is a list, the following options can be specified for each element that represents a repository to be set up:
+
+name
+####
 **description**
-  The url of the repository when ``ceph_origin`` is 'custom'.
+  The name of the repository.
+
+gpgkey
+######
+**description**
+  The url of the gpg key corresponding to the repository being set up.
+
+gpgcheck
+########
+**description**
+  Whether gpgcheck has to be performed.
+
+state
+#####
+**description**
+  Whether this repository has to be present or absent. (Default: present)
+
+description
+###########
+**description**
+  A short repository description
+
+baseurl
+#######
+**description**
+  The url of the repository pointing to the location where 'repodata' directory lives.
+
+file
+####
+**description**
+  The filename Ansible will use to write the repository file.
+
+priority
+########
+**description**
+  The priority of this repository.
 
 
-custom_repo_gpgkey
-~~~~~~~~~~~~~~~~~~
-**description**
-  The url of the gpg key corresponding to the repository set in ``custom_repo_url`` when ``ceph_origin`` is 'custom'.
+Example::
+
+  ceph_custom_repositories:
+    - name: ceph_custom_noarch
+      state: present
+      description: Ceph custom repo noarch
+      gpgcheck: 'no'
+      baseurl: https://4.chacra.ceph.com/r/ceph/main/cf17ed16c3964b635e9b6c22e607ea5672341c5c/centos/8/flavors/default/noarch
+      file: ceph_shaman_build_noarch
+      priority: '2'
+    - name: ceph_custom_x86_64
+      state: present
+      description: Ceph custom repo x86_64
+      gpgcheck: 'no'
+      baseurl: https://4.chacra.ceph.com/r/ceph/main/cf17ed16c3964b635e9b6c22e607ea5672341c5c/centos/8/flavors/default/x86_64
+      file: ceph_shaman_build_x86_64
+      priority: '2'
 
 cephadm-distribute-ssh-key
 ==========================


### PR DESCRIPTION
Current implementation allows to setup only 1 repository.
This improves the custom repository support by allowing to setup more than
one repository.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>