### PR TITLE
preflight: add backward compatibility for custom repo setup

### DIFF
--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -28,9 +28,10 @@
 
     - name: fail when ceph_origin is custom with no repository defined
       fail:
-        msg: "You must define 'ceph_custom_repositories' when ceph_origin is 'custom'"
+        msg: "You must define 'ceph_custom_repositories' or 'custom_repo_url' when ceph_origin is 'custom'"
       when:
         - ceph_origin == 'custom'
+        - custom_repo_url is undefined
         - ceph_custom_repositories is undefined
 
     - name: redhat family of OS related tasks
@@ -118,6 +119,19 @@
         - name: enable custom repo
           when: ceph_origin == 'custom'
           block:
+            - name: set_fact ceph_custom_repositories
+              set_fact:
+                ceph_custom_repositories:
+                  - name: ceph_custom
+                    description: Ceph custom repo
+                    gpgcheck: "{{ 'yes' if custom_repo_gpgkey is defined else 'no' }}"
+                    state: present
+                    gpgkey: "{{ custom_repo_gpgkey | default(omit) }}"
+                    baseurl: "{{ custom_repo_url }}"
+                    file: ceph_custom
+                    priority: '2'
+              when: ceph_custom_repositories is undefined
+
             - name: setup custom repositories
               yum_repository:
                 name: "{{ item.name }}"

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -157,10 +157,18 @@ ceph_dev_sha1
 **default**
   "latest"
 
+custom_repo_url
+~~~~~~~~~~~~~~~
+**description**
+  The url of the repository when ``ceph_origin`` is 'custom'.
+  Mutually exclusive with ``ceph_custom_repositories``.
+
 ceph_custom_repositories
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-This variable is a list, the following options can be specified for each element that represents a repository to be set up:
+This variable is a list.
+Mutually exclusive with ``custom_repo_url``.
+The following options can be specified for each element that represents a repository to be set up:
 
 name
 ####


### PR DESCRIPTION
ceph/cephadm-ansible#96 introduced multiple custom repositories support
but has broken the backward compatibility.

This commit fixes that.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit 86faa29211a3ff3c894f1bb6eb0682795086b8aa)