### PR TITLE
cephadm_bootstrap: support --allow-fqdn-hostname option

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -411,6 +411,8 @@ cephadm_bootstrap
   SSH user used for cephadm ssh to the hosts.
 ``ssh_config``
   SSH config file path for cephadm ssh client.
+``allow_fqdn_hostname``
+  Allow hostname that is fully-qualified.
 
 
 ceph_orch_host

--- a/library/cephadm_bootstrap.py
+++ b/library/cephadm_bootstrap.py
@@ -112,6 +112,11 @@ options:
         description:
             - SSH config file path for cephadm ssh client.
         required: false
+    allow_fqdn_hostname:
+        description:
+            - Allow hostname that is fully-qualified.
+        required: false
+        default: false
 author:
     - Dimitri Savineau <dsavinea@redhat.com>
 '''
@@ -160,6 +165,7 @@ def main() -> None:
             registry_json=dict(type='path', require=False),
             ssh_user=dict(type='str', required=False),
             ssh_config=dict(type='str', required=False),
+            allow_fqdn_hostname=dict(type='bool', required=False, default=False)
         ),
         supports_check_mode=True,
         mutually_exclusive=[
@@ -189,6 +195,7 @@ def main() -> None:
     registry_json = module.params.get('registry_json')
     ssh_user = module.params.get('ssh_user')
     ssh_config = module.params.get('ssh_config')
+    allow_fqdn_hostname = module.params.get('allow_fqdn_hostname')
 
     startd = datetime.datetime.now()
 
@@ -269,6 +276,9 @@ def main() -> None:
 
     if ssh_config:
         cmd.extend(['--ssh-config', ssh_config])
+
+    if allow_fqdn_hostname:
+        cmd.append('--allow-fqdn-hostname')
 
     if module.check_mode:
         exit_module(


### PR DESCRIPTION
This adds the support of the option `--allow-fqdn-hostname` to the module
`cephadm_bootstrap`.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>