### PR TITLE
doc: fix a typo in documentation

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -557,7 +557,8 @@ Bootstrap and add some hosts::
             service_type: osd
             service_id: osd
               placement:
-            label: osd
+                host_pattern: '*'
+                label: osd
             spec:
               data_devices:
                 all: true


### PR DESCRIPTION
the osd service spec is wrong, let's fix it.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
(cherry picked from commit eddf87f4f5abddee249324d4bce3aaa240595e46)