### PR TITLE
preflight: add custom_repo_state option

### DIFF
--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -125,7 +125,7 @@
                   - name: ceph_custom
                     description: Ceph custom repo
                     gpgcheck: "{{ 'yes' if custom_repo_gpgkey is defined else 'no' }}"
-                    state: present
+                    state: "{{ custom_repo_state | default('present') }}"
                     gpgkey: "{{ custom_repo_gpgkey | default(omit) }}"
                     baseurl: "{{ custom_repo_url }}"
                     file: ceph_custom

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -120,6 +120,8 @@ ceph_origin
 ``custom``
   Custom repository.
   When ``ceph_origin: custom`` is defined, you have to set the variable ``custom_repo_url`` with the URL of your repository.
+  Passing the extra-var ``-e custom_repo_state=absent`` allows you to remove this repository later.
+
   It also supports deploying multiple repositories, in that case you must set the variable ``ceph_custom_repositories`` instead.
   ``ceph_custom_repositories`` is a dictionnary that should look like following::
 


### PR DESCRIPTION
So we can disable a repository set up with `ceph_origin: custom`.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>