### PR TITLE
ceph_orch_host: fix bug when state is 'absent'

### DIFF
--- a/library/ceph_orch_host.py
+++ b/library/ceph_orch_host.py
@@ -175,6 +175,8 @@ def main() -> None:
     set_admin_label = module.params.get('set_admin_label')
     labels = module.params.get('labels')
     state = module.params.get('state')
+    if state == 'absent':
+        state = 'rm'
 
     startd = datetime.datetime.now()
     changed = False
@@ -233,7 +235,7 @@ def main() -> None:
             if not rc:
                 changed = True
 
-    if state in ['absent', 'drain']:
+    if state in ['rm', 'drain']:
         if name not in current_names:
             out = '{} is not present, skipping.'.format(name)
         else:


### PR DESCRIPTION
The module fails when trying to remove an host with a task like
following:
```
TASK [remove hosts from the cluster] ***********************************************************************************************************************************************************************
task path: /home/guillaume/workspaces/cephadm-ansible/adm-wrapper/site.yml:7
Monday 20 June 2022  20:07:14 +0200 (0:00:00.011)       0:00:00.011 ***********
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: Error EINVAL: invalid command
fatal: [ceph-node0]: FAILED! => changed=false
  ansible_facts:
    discovered_interpreter_python: /usr/libexec/platform-python
  module_stderr: ''
  module_stdout: |-
    Traceback (most recent call last):
      File "/home/vagrant/.ansible/tmp/ansible-tmp-1655748434.431962-3291840-13512576132347/AnsiballZ_ceph_orch_host.py", line 247, in <module>
        _ansiballz_main()
      File "/home/vagrant/.ansible/tmp/ansible-tmp-1655748434.431962-3291840-13512576132347/AnsiballZ_ceph_orch_host.py", line 237, in _ansiballz_main
        invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
      File "/home/vagrant/.ansible/tmp/ansible-tmp-1655748434.431962-3291840-13512576132347/AnsiballZ_ceph_orch_host.py", line 108, in invoke_module
        runpy.run_module(mod_name='ansible.modules.ceph_orch_host', init_globals=None, run_name='__main__', alter_sys=True)
      File "/usr/lib64/python3.6/runpy.py", line 205, in run_module
        return _run_module_code(code, init_globals, run_name, mod_spec)
      File "/usr/lib64/python3.6/runpy.py", line 96, in _run_module_code
        mod_name, mod_spec, pkg_name, script_name)
      File "/usr/lib64/python3.6/runpy.py", line 85, in _run_code
        exec(code, run_globals)
      File "/tmp/ansible_ceph_orch_host_payload_61mfbvvg/ansible_ceph_orch_host_payload.zip/ansible/modules/ceph_orch_host.py", line 255, in <module>
      File "/tmp/ansible_ceph_orch_host_payload_61mfbvvg/ansible_ceph_orch_host_payload.zip/ansible/modules/ceph_orch_host.py", line 240, in main
      File "/tmp/ansible_ceph_orch_host_payload_61mfbvvg/ansible_ceph_orch_host_payload.zip/ansible/modules/ceph_orch_host.py", line 147, in update_host
    RuntimeError: Inferring fsid 4217f198-b8b7-11eb-941d-5254004b7a69
    Using recent ceph image quay.ceph.io/ceph-ci/ceph@sha256:6a4c5a18f7674929cc5e9aac8f038e6834a1a4b0fdecf3a428dbb9183956c057
    /sys/class/net/eth0/type
    /sys/class/net/lo/type
    /sys/class/net/eth1/type
    /sys/class/net/eth2/type
    no valid command found; 10 closest matches:
    orch host add <hostname> [<addr>] [<labels>...] [--maintenance]
    orch host rm <hostname> [--force] [--offline]
    orch host drain <hostname> [--force]
    orch host set-addr <hostname> <addr>
    orch host ls [--format {plain|json|json-pretty|yaml|xml-pretty|xml}] [--host_pattern <value>] [--label <value>] [--host_status <value>]
    orch host label add <hostname> <label>
    orch host label rm <hostname> <label> [--force]
    orch host ok-to-stop <hostname>
    orch host maintenance enter <hostname> [--force]
    orch host maintenance exit <hostname>
    Error EINVAL: invalid command
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
  rc: 1
```

This is because the value in variable `state` is reused but the command
`ceph orch host` doesn't handle 'absent' obviously.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>