### PR TITLE
ceph_orch_host: fix type for parameter 'labels'

### DIFF
--- a/library/ceph_orch_host.py
+++ b/library/ceph_orch_host.py
@@ -155,7 +155,7 @@ def main() -> None:
             name=dict(type='str', required=True),
             address=dict(type='str', required=False),
             set_admin_label=dict(type=bool, required=False, default=False),
-            labels=dict(type=list, required=False, default=[]),
+            labels=dict(type='list', required=False, default=[]),
             state=dict(type='str',
                        required=False,
                        choices=['present', 'absent', 'drain'],


### PR DESCRIPTION
This parameter should support passing either a 'str' or a list of
'str'.

without that change, if you pass 'labels: ceph'

it will end up to the following situation:

```
Added label c to host rhceph5x-5node-1
Added label e to host rhceph5x-5node-1
Added label p to host rhceph5x-5node-1
Added label h to host rhceph5x-5node-1
```

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2103673

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>