### PR TITLE
ceph_orch_host: fix set_admin_label

### DIFF
--- a/library/ceph_orch_host.py
+++ b/library/ceph_orch_host.py
@@ -199,10 +199,10 @@ def main() -> None:
     current_names = [name['hostname'] for name in current_state]
 
     if state == 'present':
+        if set_admin_label:
+            labels.append('_admin')
         if name in current_names:
             current_state_host = [host for host in current_state if host['hostname'] == name][0]
-            if set_admin_label:
-                labels.append('_admin')
             if labels:
                 differences = set(labels) ^ set(current_state_host['labels'])
                 if differences:


### PR DESCRIPTION
When adding a new host with `set_admin_label: true` this parameter
isn't honoured.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2103686

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>