### PR TITLE
playbooks: add new playbook 'cephadm-set-container-insecure-registries'

### DIFF
--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -18,6 +18,9 @@
 # ansible-playbook -i <inventory host file> cephadm-preflight.yml --extra-vars "ceph_origin=rhcs"
 #
 
+- name: variables validations
+  ansible.builtin.import_playbook: validate/preflight.yml
+
 - hosts: all
   become: true
   gather_facts: true
@@ -25,14 +28,6 @@
     - name: import_role ceph_defaults
       import_role:
         name: ceph_defaults
-
-    - name: fail when ceph_origin is custom with no repository defined
-      fail:
-        msg: "You must define 'ceph_custom_repositories' or 'custom_repo_url' when ceph_origin is 'custom'"
-      when:
-        - ceph_origin == 'custom'
-        - custom_repo_url is undefined
-        - ceph_custom_repositories is undefined
 
     - name: redhat family of OS related tasks
       when: ansible_facts['distribution'] == 'CentOS' or ansible_facts['distribution'] == 'RedHat'
@@ -279,3 +274,7 @@
                     - docker-ce
                     - docker-ce-cli
                     - containerd.io
+
+- name: set insecure container registry in /etc/containers/registries.conf
+  ansible.builtin.import_playbook: cephadm-set-container-insecure-registries.yml
+  when: set_insecure_registries | default(false) | bool

--- a/cephadm-set-container-insecure-registries.yml
+++ b/cephadm-set-container-insecure-registries.yml
@@ -1,0 +1,36 @@
+---
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+# Author: Guillaume Abrioux <gabrioux@redhat.com>
+#
+# Usage:
+#
+# ansible-playbook -i <inventory host file> cephadm-set-container-insecure-registries.yml -e insecure_registry=<registry url>
+#
+# eg:
+#
+# ansible-playbook -i hosts cephadm-set-container-insecure-registries.yml -e insecure_registry=localhost:5000
+
+- name: variables validations
+  ansible.builtin.import_playbook: validate/insecure-registries.yml
+
+- hosts: all
+  become: true
+  gather_facts: false
+  tasks:
+    - name: fail if insecure_registry is undefined
+      fail:
+        msg: "'insecure_registry' is undefined"
+      when: insecure_registry is undefined
+
+    - name: add registry as insecure registry in registries.conf
+      blockinfile:
+        path: "{{ registries_conf_path | default('/etc/containers/registries.conf') }}"
+        state: present
+        marker: "# {mark} cephadm-ansible managed : {{ insecure_registry }}"
+        create: yes
+        mode: '0644'
+        block: |
+          [[registry]]
+          location = '{{ insecure_registry }}'
+          insecure = true

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -10,6 +10,7 @@ workflows that are not covered by [cephadm]_. They are covered by the following 
 * cephadm-clients.yml: Setting up client hosts
 * cephadm-purge-cluster.yml: Remove a Ceph cluster
 * cephadm-distribute-ssh-key.yml: Distribute a SSH public key to all hosts
+* cephadm-set-container-insecure-registries.yml: Add a block in /etc/containers/registries.conf to add an insecure registry
 
 Additionnally, several ansible modules are provided in order to let people writing their own playbooks.
 
@@ -277,6 +278,37 @@ Example::
       baseurl: https://4.chacra.ceph.com/r/ceph/main/cf17ed16c3964b635e9b6c22e607ea5672341c5c/centos/8/flavors/default/x86_64
       file: ceph_shaman_build_x86_64
       priority: '2'
+
+set_insecure_registries
+~~~~~~~~~~~~~~~~~~~~~~~
+**description**
+  Whether ``cephadm-preflight.yml`` playbook will call ``cephadm-set-container-insecure-registries.yml`` to add an insecure registry in ``/etc/containers/registries.conf``.
+  ``insecure_registry`` option must be passed (-e insecure_registry=<registry url>)
+
+**default**
+  false
+
+cephadm-set-container-insecure-registries
+=========================================
+
+This playbook adds a block in ``/etc/containers/registries.conf`` in order to allow an insecure registry to be used.
+
+Usage::
+
+   ansible-playbook -i <inventory host file> cephadm-set-container-insecure-registries.yml -e insecure_registry=<registry url>
+
+
+
+Options
++++++++
+
+insecure_registry
+~~~~~~~~~~~~~~~~~
+**description**
+  The address of the insecure registry to be added to ``/etc/containers/registries.conf``.
+
+**default**
+  No default.
 
 cephadm-distribute-ssh-key
 ==========================

--- a/validate/insecure-registries.yml
+++ b/validate/insecure-registries.yml
@@ -1,0 +1,15 @@
+---
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+# Author: Guillaume Abrioux <gabrioux@redhat.com>
+
+- hosts: localhost
+  become: false
+  gather_facts: false
+  tasks:
+    - name: fail if insecure_registry is undefined
+      fail:
+        msg: "'insecure_registry' is undefined, it must be set when 'set_insecure_registries' is 'true'."
+      when:
+        - set_insecure_registries | default(false) | bool
+        - insecure_registry is undefined

--- a/validate/preflight.yml
+++ b/validate/preflight.yml
@@ -1,0 +1,23 @@
+---
+# Copyright Red Hat
+# SPDX-License-Identifier: Apache-2.0
+# Author: Guillaume Abrioux <gabrioux@redhat.com>
+
+- ansible.builtin.import_playbook: insecure-registries.yml
+  when: set_insecure_registries | default(false) | bool
+
+- hosts: localhost
+  become: false
+  gather_facts: false
+  tasks:
+    - name: import_role ceph_defaults
+      import_role:
+        name: ceph_defaults
+
+    - name: fail when ceph_origin is custom with no repository defined
+      fail:
+        msg: "You must define 'ceph_custom_repositories' or 'custom_repo_url' when ceph_origin is 'custom'"
+      when:
+        - ceph_origin == 'custom'
+        - custom_repo_url is undefined
+        - ceph_custom_repositories is undefined


### PR DESCRIPTION
This playbook can be called directly or can be a step of cephadm-preflight.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2040337

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>