### PR TITLE
preflight: support el9 repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Options:
 **default**: pacific
 
 `ceph_dev_branch`: The development branch to be used in shaman when `ceph_origin` is 'shaman'.\
-**default**: master
+**default**: main
 
 `ceph_dev_sha1`: The sha1 corresponding to the build to be used when `ceph_origin` is 'shaman'.\
 **default**: latest

--- a/ceph_defaults/defaults/main.yml
+++ b/ceph_defaults/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 ceph_origin: community
-ceph_dev_branch: master
+ceph_dev_branch: main
 ceph_dev_sha1: latest
 ceph_rhcs_version: 5
 ceph_mirror: https://download.ceph.com

--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -42,7 +42,7 @@
           block:
             - name: enable red hat storage tools repository
               rhsm_repository:
-                name: "rhceph-{{ ceph_rhcs_version }}-tools-for-rhel-8-{{ ansible_facts['architecture'] }}-rpms"
+                name: "rhceph-{{ ceph_rhcs_version }}-tools-for-rhel-{{ ansible_facts['distribution_major_version'] }}-{{ ansible_facts['architecture'] }}-rpms"
 
             - name: disable older rhceph repositories if any
               rhsm_repository:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -190,7 +190,7 @@ ceph_dev_branch
   The development branch to be used in shaman when `ceph_origin` is 'shaman'.
 
 **default**
-  "master"
+  "main"
 
 ceph_dev_sha1
 ~~~~~~~~~~~~~

--- a/library/cephadm_bootstrap.py
+++ b/library/cephadm_bootstrap.py
@@ -134,7 +134,7 @@ EXAMPLES = '''
   cephadm_bootstrap:
     mon_ip: 192.168.42.1
     fsid: 3c9ba63a-c7df-4476-a1e7-317dfc711f82
-    image: quay.ceph.io/ceph/daemon-base:latest-master-devel
+    image: quay.ceph.io/ceph/daemon-base:latest-main-devel
     dashboard: false
     monitoring: false
     firewalld: false
@@ -143,7 +143,7 @@ EXAMPLES = '''
   cephadm_bootstrap:
     mon_ip: 192.168.42.1
   environment:
-    CEPHADM_IMAGE: quay.ceph.io/ceph/daemon-base:latest-master-devel
+    CEPHADM_IMAGE: quay.ceph.io/ceph/daemon-base:latest-main-devel
 '''
 
 RETURN = '''#  '''

--- a/module_utils/ceph_common.py
+++ b/module_utils/ceph_common.py
@@ -87,4 +87,4 @@ def fatal(message: str, module: "AnsibleModule") -> None:
     if module:
         module.fail_json(msg=message, rc=1)
     else:
-        raise(Exception(message))
+        raise Exception(message)

--- a/tests/library/test_cephadm_bootstrap.py
+++ b/tests/library/test_cephadm_bootstrap.py
@@ -4,7 +4,7 @@ import common
 import cephadm_bootstrap
 
 fake_fsid = '0f1e0605-db0b-485c-b366-bd8abaa83f3b'
-fake_image = 'quay.ceph.io/ceph/daemon-base:latest-master-devel'
+fake_image = 'quay.ceph.io/ceph/daemon-base:latest-main-devel'
 fake_ip = '192.168.42.1'
 fake_registry = 'quay.ceph.io'
 fake_registry_user = 'foo'


### PR DESCRIPTION
rhel 8 repo is hardcoded.
Let's use ansible_facts['distribution_major_version'] instead so
el9 can be set up.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2116825

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>