### PR TITLE
preflight: remove old rhceph 4 only on el8

### DIFF
--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -52,6 +52,7 @@
                 - rhceph-4-tools-for-rhel-8-{{ ansible_facts['architecture'] }}-rpms
                 - rhceph-4-mon-for-rhel-8-{{ ansible_facts['architecture'] }}-rpms
                 - rhceph-4-osd-for-rhel-8-{{ ansible_facts['architecture'] }}-rpms
+              when: ansible_facts['architecture'] | int == 8
 
         - name: enable repo from download.ceph.com
           when: ceph_origin == 'community'


### PR DESCRIPTION
This task doesn't make sense when running on el9 and makes the playbook fail.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2124919

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>