### PR TITLE
preflight: fix a typo

### DIFF
--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -52,7 +52,7 @@
                 - rhceph-4-tools-for-rhel-8-{{ ansible_facts['architecture'] }}-rpms
                 - rhceph-4-mon-for-rhel-8-{{ ansible_facts['architecture'] }}-rpms
                 - rhceph-4-osd-for-rhel-8-{{ ansible_facts['architecture'] }}-rpms
-              when: ansible_facts['architecture'] | int == 8
+              when: ansible_facts['distribution_major_version'] | int == 8
 
         - name: enable repo from download.ceph.com
           when: ceph_origin == 'community'


### PR DESCRIPTION
46d6d59b1ea05cb0ddc79299aa39f51750202cb4 introduced a typo

'distribution_major_version' is the fact i wanted to use intead.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2124919

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>