### PR TITLE
Fix indentention in `ceph_orch_apply` examples

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -641,14 +641,14 @@ Bootstrap and add some hosts::
        - name: apply osd spec
          ceph_orch_apply:
          spec: |
-            service_type: osd
-            service_id: osd
-              placement:
-                host_pattern: '*'
-                label: osd
-            spec:
-              data_devices:
-                all: true
+           service_type: osd
+           service_id: osd
+           placement:
+             host_pattern: '*'
+             label: osd
+           spec:
+             data_devices:
+               all: true
 
    - name: change osd_default_notify_timeout option
      hosts: ceph-mon1

--- a/library/ceph_orch_apply.py
+++ b/library/ceph_orch_apply.py
@@ -58,15 +58,15 @@ author:
 
 EXAMPLES = '''
 - name: apply osd spec
-    ceph_orch_apply:
+  ceph_orch_apply:
     spec: |
-        service_type: osd
-        service_id: osd
-        placement:
+      service_type: osd
+      service_id: osd
+      placement:
         label: osds
-        spec:
+      spec:
         data_devices:
-            all: true
+          all: true
 '''
 
 


### PR DESCRIPTION
The indention in the `ceph_orch_apply` examples is wrong, leading to confusion when one uses this module for the first time.