### PR TITLE
switch to "delegate_to: localhost" for purge playbook

### DIFF
--- a/cephadm-purge-cluster.yml
+++ b/cephadm-purge-cluster.yml
@@ -13,7 +13,7 @@
 
 
 - name: check local prerequisites are in place
-  hosts: localhost
+  hosts: all
   gather_facts: false
   become: true
   any_errors_fatal: true
@@ -24,6 +24,8 @@
         msg: |
           You must provide the cluster fsid to be purged.
           e.g. ansible-playbook -i <inventory host file> cephadm-purge-cluster.yml -e fsid=<your fsid>
+      run_once: true
+      delegate_to: localhost
       when: fsid is undefined
 
     - name: fail if admin group doesn't exist or is empty
@@ -31,6 +33,8 @@
         msg: |
           You must define a group [admin] in your inventory and add a node where
           admin keyring is present at /etc/ceph/admin.client.keyring
+      run_once: true
+      delegate_to: localhost
       when: "'admin' not in groups or groups['admin'] | length < 1"
 
 
@@ -96,7 +100,7 @@
 
 
 - name: confirm whether user really wants to purge the cluster
-  hosts: localhost
+  hosts: all
   gather_facts: false
   become: false
 
@@ -115,6 +119,8 @@
             Exiting cephadm-purge-cluster playbook, cluster was NOT purged.
             To purge the cluster, either say 'yes' at the prompt or use `-e ireallymeanit=yes`
             on the command line when invoking the playbook
+      run_once: true
+      delegate_to: localhost
       when: ireallymeanit != 'yes'
 
 


### PR DESCRIPTION
This PR fixes #170.

I noticed a few other references to `hosts: localhost` in other playbooks I haven't used; should I update these the same way?

```
$ grep -rn 'hosts: localhost' .
./validate/preflight.yml:9:- hosts: localhost
./validate/insecure-registries.yml:6:- hosts: localhost
./rocksdb-resharding.yml:25:- hosts: localhost
./cephadm-clients.yml:29:  hosts: localhost
```

# Q/A
With the fix in place, passing `-l` to the playbook allows it to abort after the prompt:
```
$ ansible-playbook -i inventory -l ceph cephadm-ansible/cephadm-purge-cluster.yml -e fsid=bcf88dfa-3cf0-11ed-b5a4-b19cff2a0492

PLAY [check local prerequisites are in place] ************************************************************************************************************

TASK [fail if fsid was not provided] *********************************************************************************************************************
skipping: [loyal_mouse]

TASK [fail if admin group doesn't exist or is empty] *****************************************************************************************************
skipping: [loyal_mouse]

PLAY [check keyring is present on the admin host] ********************************************************************************************************

TASK [check /etc/ceph/ceph.admin.client.keyring] *********************************************************************************************************
ok: [loyal_mouse]

TASK [fail if /etc/ceph/admin.client.keyring is not present] *********************************************************************************************
skipping: [loyal_mouse]

PLAY [check cluster hosts have cephadm and the required fsid bcf88dfa-3cf0-11ed-b5a4-b19cff2a0492] *******************************************************

TASK [check cephadm binary is available] *****************************************************************************************************************
ok: [loyal_mouse]
ok: [tidy_piglet]
ok: [tender_poodle]

TASK [fail if cephadm is not available] ******************************************************************************************************************
skipping: [loyal_mouse]
skipping: [tender_poodle]
skipping: [tidy_piglet]

TASK [check fsid directory given is valid across the cluster] ********************************************************************************************
ok: [tender_poodle]
ok: [tidy_piglet]
ok: [loyal_mouse]

TASK [fail if the fsid directory is missing] *************************************************************************************************************
skipping: [loyal_mouse]
skipping: [tender_poodle]
skipping: [tidy_piglet]

Are you sure you want to purge the cluster with fsid=bcf88dfa-3cf0-11ed-b5a4-b19cff2a0492 ?
 [no]: no

PLAY [confirm whether user really wants to purge the cluster] ********************************************************************************************

TASK [exit playbook, if user did not mean to purge cluster] **********************************************************************************************
fatal: [loyal_mouse -> localhost]: FAILED! => {"changed": false, "msg": "Exiting cephadm-purge-cluster playbook, cluster was NOT purged.\nTo purge the cluster, either say 'yes' at the prompt or use `-e ireallymeanit=yes`\non the command line when invoking the playbook\n"}

NO MORE HOSTS LEFT ***************************************************************************************************************************************

PLAY RECAP ***********************************************************************************************************************************************
loyal_mouse                : ok=3    changed=0    unreachable=0    failed=1    skipped=5    rescued=0    ignored=0   
tender_poodle              : ok=2    changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0   
tidy_piglet                : ok=2    changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0  
```