### PR TITLE
Changed "distribution" to "os_family" to include Debian

### DIFF
--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -177,14 +177,14 @@
             state: started
             enabled: yes
 
-    - name: Ubuntu related tasks
-      when: ansible_facts['distribution'] == 'Ubuntu'
+    - name: Debian based related tasks
+      when: ansible_facts['os_family'] == 'Debian'
       block:
         - name: enable repo from download.ceph.com
           block:
             - name: prevent ceph certificate error
               apt:
-                name: ca-certificates
+                name: ca-certificates, gnupg2
                 state: latest
                 update_cache: yes
               register: result
@@ -230,8 +230,12 @@
 
         - name: install container engine
           block:
+            - name: verify if podman exists
+              command: apt-cache search '^podman$'
+              register: podman_package
+
             - name: install podman
-              when: ansible_facts['distribution_version'] is version('20.10', '>=')
+              when: podman_package.stdout != ''
               apt:
                 name: podman
                 state: present
@@ -240,7 +244,7 @@
               until: result is succeeded
 
             - name: install docker
-              when: ansible_facts['distribution_version'] is version('20.10', '<')
+              when: podman_package.stdout == ''
               block:
                 - name: uninstall old version packages
                   apt:
@@ -255,12 +259,12 @@
 
                 - name: configure docker repository key
                   apt_key:
-                    url: "https://download.docker.com/linux/ubuntu/gpg"
+                    url: "https://download.docker.com/linux/debian/gpg"
                     state: present
 
                 - name: setup docker repository
                   apt_repository:
-                    repo: "deb https://download.docker.com/linux/ubuntu {{ ansible_facts['distribution_release'] }} stable"
+                    repo: "deb https://download.docker.com/linux/{{ ansible_facts['distribution']|lower }} {{ ansible_facts['distribution_release'] }} stable"
                     state: present
                     filename: docker
                     update_cache: no


### PR DESCRIPTION
Changed the `when` variable from `distribution` to `os_family` to include Debian, Ubuntu and possibly other debian based distros too. Instead of install podman or docker by distribution version, the playbook now search for the podman package in the repositories, if the package exists, install it, if not, install docker.