### PR TITLE
preflight: fix a typo

### DIFF
--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -139,7 +139,7 @@
                 baseurl: "{{ item.baseurl }}"
                 file: "{{ item.ceph_custom | default(omit) }}"
                 priority: "{{ item.priority | default(omit) }}"
-                enabled: "{{ item.enabled | defualt(omit) }}"
+                enabled: "{{ item.enabled | default(omit) }}"
               register: result
               until: result is succeeded
               loop: "{{ ceph_custom_repositories }}"

--- a/library/ceph_orch_host.py
+++ b/library/ceph_orch_host.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import, division, print_function
-from typing import List, Tuple
+from typing import Optional, List, Tuple
 __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule  # type: ignore
@@ -134,7 +134,7 @@ def update_host(module: "AnsibleModule",
                 action: str,
                 name: str,
                 address: str = '',
-                labels: List[str] = None) -> Tuple[int, List[str], str, str]:
+                labels: Optional[List[str]] = None) -> Tuple[int, List[str], str, str]:
     cmd = build_base_cmd_orch(module)
     cmd.extend(['host', action, name])
     if action == 'add' and address:


### PR DESCRIPTION
d13b9a1d introduced a typo.

This commit fixes it.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2148827

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>