### PR TITLE
tests: address a warning deprecation (vagrant)

### DIFF
--- a/tests/functional/Vagrantfile
+++ b/tests/functional/Vagrantfile
@@ -31,7 +31,7 @@ Vagrant.configure('2') do |config|
   config.ssh.username = 'vagrant'
   config.vm.provider :libvirt do |lv|
     lv.cpu_mode = 'host-passthrough'
-    lv.volume_cache = 'unsafe'
+    lv.disk_driver :cache => 'unsafe'
     lv.graphics_type = 'none'
     lv.cpus = 4
   end


### PR DESCRIPTION
In order to address the following warning from vagrant:

```
Libvirt Provider: volume_cache is deprecated. Use disk_driver :cache =>
'unsafe' instead.
```

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>