### PR TITLE
rpm: switch to ansible-core on RHEL 8

### DIFF
--- a/cephadm-ansible.spec.in
+++ b/cephadm-ansible.spec.in
@@ -11,15 +11,10 @@ Source0:        %{name}-%{version}-%{shortcommit}.tar.gz
 
 BuildArch:      noarch
 
-%if 0%{?el8}
-BuildRequires: ansible >= 2.9
-Requires: ansible >= 2.9
-%else
 BuildRequires: ansible-core >= 2.9
 BuildRequires: ansible-collection-community-general
 Requires: ansible-core >= 2.9
 Requires: ansible-collection-community-general
-%endif
 
 %description
 cephadm-ansible is a collection of Ansible playbooks to simplify workflows that are not covered by cephadm.


### PR DESCRIPTION
RHEL 8.6+ ships `ansible-core`. This version is much newer and better-supported than the old ansible package in the `ansible-2.9-for-rhel-8-x86_64-rpms` repository.

Update the el8 packaging to depend on `ansible-core` instead of `ansible`.