### PR TITLE
whitelist_externals in tox.ini deprecated

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ setenv=
 commands = py.test -vvv -n=auto {toxinidir}/tests/library/ {toxinidir}/tests/module_utils
 
 [testenv:{el8,el9}-functional]
-whitelist_externals =
+allowlist_externals =
     vagrant
     bash
     pip


### PR DESCRIPTION
Replaced by allowlist_externals

https://tox.wiki/en/latest/changelog.html#deprecations-and-removals-4-0-0rc4

Signed-off-by: Teoman ONAY <tonay@ibm.com>