### PR TITLE
validate: check for empty url (ceph_origin=custom)

### DIFF
--- a/tests/scripts/vagrant_up.sh
+++ b/tests/scripts/vagrant_up.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ex
+
 if [[ "${CEPH_ANSIBLE_VAGRANT_BOX}" =~ "centos/stream" ]]; then
   EL_VERSION="${CEPH_ANSIBLE_VAGRANT_BOX: -1}"
   LATEST_IMAGE="$(curl -s https://cloud.centos.org/centos/${EL_VERSION}-stream/x86_64/images/CHECKSUM | sed -nE 's/^SHA256.*\((.*-([0-9]+).*vagrant-libvirt.box)\).*$/\1/p' | sort -u | tail -n1)"

--- a/validate/preflight.yml
+++ b/validate/preflight.yml
@@ -19,7 +19,7 @@
         msg: "You must define 'ceph_custom_repositories' or 'custom_repo_url' when ceph_origin is 'custom'"
       when:
         - ceph_origin == 'custom'
-        - custom_repo_url is undefined
+        - (custom_repo_url is undefined or custom_repo_url == '')
         - ceph_custom_repositories is undefined
 
     - name: fail if baseurl is not defined for ceph_custom_repositories


### PR DESCRIPTION
This checks if `custom_repo_url` is set to an empty string and makes the playbook fail in that case.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2097680

Signed-off-by: Guillaume Abrioux <gabrioux@ibm.com>