### PR TITLE
preflight: fix path for IBM GPG key

### DIFF
--- a/ceph_defaults/defaults/main.yml
+++ b/ceph_defaults/defaults/main.yml
@@ -8,7 +8,7 @@ ceph_mirror: https://download.ceph.com
 ceph_stable_key: https://download.ceph.com/keys/release.asc
 ceph_community_repo_baseurl: "{{ ceph_mirror }}/rpm-{{ ceph_release }}/el{{ ansible_facts['distribution_major_version'] }}/"
 ceph_ibm_repo_baseurl: "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/{{ ceph_ibm_version }}/rhel{{ ansible_facts['distribution_major_version'] }}/"
-ceph_ibm_key: https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/5/rhel8/ibm-key.asc
+ceph_ibm_key: https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/RPM-GPG-KEY-IBM-CEPH
 ceph_release: quincy
 upgrade_ceph_packages: false
 ceph_pkgs:


### PR DESCRIPTION
Move to the top level directory, and copy the file naming convention that Red Hat and EPEL use.