### PR TITLE
library: fix a bug in ceph_config module

### DIFF
--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -144,8 +144,8 @@
         - name: install epel-release
           when: ansible_facts['distribution'] == 'CentOS'
           block:
-            - name: enable CentOS PowerTools repository for epel
-              command: dnf config-manager --set-enabled powertools
+            - name: enable required CentOS repository for epel
+              command: dnf config-manager --set-enabled "{{ 'powertools' if ansible_facts['distribution_major_version'] == '8' else 'crb' }}"
               changed_when: false
 
             - name: install package


### PR DESCRIPTION
`ceph config get` doesn't allow getting value when entity is 'global' so it makes the module fail. Indeed, the module first tries to get the current value of the option for idempotency concern. The idea is to check in `ceph config dump` instead.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2188319