### PR TITLE
add posiblity to skip prepare-host

### DIFF
--- a/library/cephadm_bootstrap.py
+++ b/library/cephadm_bootstrap.py
@@ -121,6 +121,11 @@ options:
         description:
             - subnet to use for cluster replication, recovery and heartbeats.
         required: false
+    skip_prepare_host:
+        description:
+            -  Do not prepare host.
+        required: false
+        default: false
 author:
     - Dimitri Savineau <dsavinea@redhat.com>
 '''
@@ -171,6 +176,7 @@ def main() -> None:
             ssh_config=dict(type='str', required=False),
             allow_fqdn_hostname=dict(type='bool', required=False, default=False),
             cluster_network=dict(type='str', required=False),
+            skip_prepare_host=dict(type='bool', required=False, default=False),
         ),
         supports_check_mode=True,
         mutually_exclusive=[
@@ -202,6 +208,7 @@ def main() -> None:
     ssh_config = module.params.get('ssh_config')
     allow_fqdn_hostname = module.params.get('allow_fqdn_hostname')
     cluster_network = module.params.get('cluster_network')
+    skip_prepare_host = module.params.get('skip_prepare_host')
 
     startd = datetime.datetime.now()
 
@@ -268,6 +275,9 @@ def main() -> None:
 
     if allow_overwrite:
         cmd.append('--allow-overwrite')
+
+    if skip_prepare_host:
+        cmd.append('--skip-prepare-host')
 
     if registry_url and registry_username and registry_password:
         cmd.extend(['--registry-url', registry_url,

--- a/tests/library/test_cephadm_bootstrap.py
+++ b/tests/library/test_cephadm_bootstrap.py
@@ -302,3 +302,23 @@ class TestCephadmBootstrapModule(object):
         assert result['cmd'] == ['cephadm', 'bootstrap', '--mon-ip', fake_ip,
                                  '--registry-json', fake_registry_json]
         assert result['rc'] == 0
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_with_skip_prepare_host(self, m_run_command, m_exit_json):
+        common.set_module_args({
+            'mon_ip': fake_ip
+        })
+        m_exit_json.side_effect = common.exit_json
+        stdout = ''
+        stderr = ''
+        rc = 0
+        m_run_command.return_value = rc, stdout, stderr
+
+        with pytest.raises(common.AnsibleExitJson) as result:
+            cephadm_bootstrap.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['cmd'] == ['cephadm', 'bootstrap', '--mon-ip', fake_ip, '--skip-prepare-host']
+        assert result['rc'] == 0


### PR DESCRIPTION
This commit adds the ability to use skip-prepare-host as an argument in the ansible module. This is useful if you don't want to use Chrony or other services that are needed here or if you want to set up the services yourself.
I would be grateful if you could include this change.
