### PR TITLE
rpm: require ansible-posix collection package

### DIFF
--- a/cephadm-ansible.spec.in
+++ b/cephadm-ansible.spec.in
@@ -12,8 +12,10 @@ Source0:        %{name}-%{version}-%{shortcommit}.tar.gz
 BuildArch:      noarch
 
 BuildRequires: ansible-core >= 2.9
+BuildRequires: ansible-collection-ansible-posix
 BuildRequires: ansible-collection-community-general
 Requires: ansible-core >= 2.9
+Requires: ansible-collection-ansible-posix
 Requires: ansible-collection-community-general
 
 %description


### PR DESCRIPTION
The `cephadm-distribute-ssh-key.yml` playbook uses the [`authorized_key` module](https://docs.ansible.com/ansible/latest/collections/ansible/posix/authorized_key_module.html), and Ansible ships that in the ansible.posix collection now.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2203747