### PR TITLE
preflight: old repos disablement refactor

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,6 +3,13 @@ pull_request_rules:
   - actions:
       backport:
         branches:
+          - reef
+    conditions:
+      - label=backport-reef
+    name: backport reef
+  - actions:
+      backport:
+        branches:
           - quincy
     conditions:
       - label=backport-quincy

--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -24,6 +24,12 @@
 - hosts: all
   become: true
   gather_facts: true
+  vars:
+    repos_to_disable:
+      - rhceph-4-tools-for-rhel-{{ ansible_facts['distribution_major_version'] }}-{{ ansible_facts['architecture'] }}-rpms
+      - rhceph-4-mon-for-rhel-{{ ansible_facts['distribution_major_version'] }}-{{ ansible_facts['architecture'] }}-rpms
+      - rhceph-4-osd-for-rhel-{{ ansible_facts['distribution_major_version'] }}-{{ ansible_facts['architecture'] }}-rpms
+      - rhceph-5-tools-for-rhel-{{ ansible_facts['distribution_major_version'] }}-{{ ansible_facts['architecture'] }}-rpms
   tasks:
     - name: import_role ceph_defaults
       import_role:
@@ -41,13 +47,8 @@
 
             - name: disable older rhceph repositories if any
               rhsm_repository:
-                name: "{{ item }}"
+                name: "{{ repos_to_disable }}"
                 state: absent
-              loop:
-                - rhceph-4-tools-for-rhel-8-{{ ansible_facts['architecture'] }}-rpms
-                - rhceph-4-mon-for-rhel-8-{{ ansible_facts['architecture'] }}-rpms
-                - rhceph-4-osd-for-rhel-8-{{ ansible_facts['architecture'] }}-rpms
-              when: ansible_facts['distribution_major_version'] | int == 8
 
         - name: enable ceph package repositories
           when: ceph_origin in ['community', 'ibm']


### PR DESCRIPTION
This refacts the task that disables old repositories. The speeds up this task which seems to be currently very time consuming.

```
TASK [disable older rhceph repositories if any] ****************************
changed: [localhost] => (item=rhceph-4-tools-for-rhel-8-x86_64-rpms)
changed: [localhost] => (item=rhceph-4-mon-for-rhel-8-x86_64-rpms)
changed: [localhost] => (item=rhceph-4-osd-for-rhel-8-x86_64-rpms)
changed: [localhost] => (item=rhceph-5-tools-for-rhel-8-x86_64-rpms)

PLAY RECAP *****************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

real	3m18.439s
```

```
TASK [disable older rhceph repositories if any] ***********
changed: [localhost]

PLAY RECAP ***********************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

real	0m47.198s
```

Also, this makes sure all previous repositories are disabled for both el8 and el9.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2181243