### PR TITLE
Uninstall old ceph packages before upgrading ceph-common

### DIFF
--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -30,6 +30,13 @@
       - rhceph-4-mon-for-rhel-{{ ansible_facts['distribution_major_version'] }}-{{ ansible_facts['architecture'] }}-rpms
       - rhceph-4-osd-for-rhel-{{ ansible_facts['distribution_major_version'] }}-{{ ansible_facts['architecture'] }}-rpms
       - rhceph-5-tools-for-rhel-{{ ansible_facts['distribution_major_version'] }}-{{ ansible_facts['architecture'] }}-rpms
+    packages_to_uninstall:
+      - ceph-mds
+      - ceph-mgr
+      - ceph-mon
+      - ceph-osd
+      - ceph-radosgw
+      - rbd-mirror
   tasks:
     - name: import_role ceph_defaults
       import_role:
@@ -156,9 +163,16 @@
               register: result
               until: result is succeeded
 
+        - name: remove remaining local services ceph packages
+          dnf:
+            name: "{{ packages_to_uninstall }}"
+            state: absent
+            autoremove: no
+
         - name: install ceph-common on rhel
-          command: dnf install --allowerasing --assumeyes ceph-common
-          changed_when: false
+          package:
+            name: ceph-common
+            state: "{{ (upgrade_ceph_packages | bool) | ternary('latest', 'present') }}"
           register: result
           until: result is succeeded
 


### PR DESCRIPTION
Removing the existing packages prevents depsolv conflit when upgrading ceph-common