### PR TITLE
rpm: set Epoch to 1

### DIFF
--- a/cephadm-ansible.spec.in
+++ b/cephadm-ansible.spec.in
@@ -8,6 +8,7 @@ Summary:        ansible playbooks to be used with cephadm
 License:        ASL 2.0
 URL:            https://github.com/ceph/cephadm-ansible
 Source0:        %{name}-%{version}-%{shortcommit}.tar.gz
+Epoch:          1
 
 BuildArch:      noarch
 


### PR DESCRIPTION
This will override all usual version comparisons.

In RHCS 6, we shipped v3, and we want users to go back to v2 ([rhbz#2244978](https://bugzilla.redhat.com/show_bug.cgi?id=2244978)). This epoch bump will cause users to "upgrade" to the highest epoch version. We will apply this change to RHCS 6+.

Apply it upstream as well so that we keep parity with downstream and preserve the ability to upgrade from downstream -> upstream versions.