### PR TITLE
Create `requirements.yml` for `community.general`

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - community.general


### PR DESCRIPTION
This fixes https://github.com/ceph/cephadm-ansible/issues/246. This has been tested to work on AWX 23.3.0 with variables from `cephdefaults/defaults/main.yml` (the only change being that `ceph_release` is set to `reef`).