### PR TITLE
Fix oldrepos:  Ceph 4 repositories are not available on RHEL9 

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/source/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - requirements: ./requirements.txt

--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -25,10 +25,11 @@
   become: true
   gather_facts: true
   vars:
-    repos_to_disable:
+    repos_4_to_disable:
       - rhceph-4-tools-for-rhel-{{ ansible_facts['distribution_major_version'] }}-{{ ansible_facts['architecture'] }}-rpms
       - rhceph-4-mon-for-rhel-{{ ansible_facts['distribution_major_version'] }}-{{ ansible_facts['architecture'] }}-rpms
       - rhceph-4-osd-for-rhel-{{ ansible_facts['distribution_major_version'] }}-{{ ansible_facts['architecture'] }}-rpms
+    repos_5_to_disable:
       - rhceph-5-tools-for-rhel-{{ ansible_facts['distribution_major_version'] }}-{{ ansible_facts['architecture'] }}-rpms
     packages_to_uninstall:
       - ceph-mds
@@ -52,9 +53,16 @@
               rhsm_repository:
                 name: "rhceph-{{ ceph_rhcs_version }}-tools-for-rhel-{{ ansible_facts['distribution_major_version'] }}-{{ ansible_facts['architecture'] }}-rpms"
 
-            - name: disable older rhceph repositories if any
+            - name: disable older rhceph repositories if any on RHEL{{ansible_facts['distribution_major_version']}}
+              when: ansible_facts['distribution_major_version'] == '8'
               rhsm_repository:
-                name: "{{ repos_to_disable }}"
+                name: "{{ repos_4_to_disable + repos_5_to_disable }}"
+                state: absent
+
+            - name: disable older rhceph repositories if any on RHEL{{ansible_facts['distribution_major_version']}}
+              when: ansible_facts['distribution_major_version'] == '9'
+              rhsm_repository:
+                name: "{{ repos_5_to_disable }}"
                 state: absent
 
         - name: enable ceph package repositories

--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -88,7 +88,7 @@
               yum_repository:
                 name: "ceph_stable_{{ item }}"
                 description: "{{ _ceph_repo.description }} - {{ item }}"
-                gpgcheck: yes
+                gpgcheck: true
                 state: present
                 gpgkey: "{{ _ceph_repo.rpm_key }}"
                 baseurl: "{{ _ceph_repo.baseurl }}/{{ item }}"
@@ -103,8 +103,13 @@
           block:
             - name: fetch ceph development repository
               uri:
-                url: https://shaman.ceph.com/api/repos/ceph/{{ ceph_dev_branch }}/{{ ceph_dev_sha1 }}/centos/{{ ansible_facts['distribution_major_version'] }}/repo?arch={{ ansible_facts['architecture'] }}  # noqa 204
-                return_content: yes
+                url:
+                  "https://shaman.ceph.com/api/repos/ceph/\
+                  {{ ceph_dev_branch }}/\
+                  {{ ceph_dev_sha1 }}/\
+                  centos/{{ ansible_facts['distribution_major_version'] }}/\
+                  repo?arch={{ ansible_facts['architecture'] }}"
+                return_content: true
               register: ceph_dev_yum_repo
 
             - name: configure ceph development repository
@@ -114,7 +119,7 @@
                 owner: root
                 group: root
                 mode: '0644'
-                backup: yes
+                backup: true
 
             - name: remove ceph_stable repositories
               yum_repository:
@@ -175,7 +180,7 @@
           dnf:
             name: "{{ packages_to_uninstall }}"
             state: absent
-            autoremove: no
+            autoremove: false
 
         - name: install ceph-common on rhel
           package:
@@ -195,7 +200,7 @@
           service:
             name: chronyd
             state: started
-            enabled: yes
+            enabled: true
 
     - name: Ubuntu related tasks
       when: ansible_facts['distribution'] == 'Ubuntu'
@@ -206,7 +211,7 @@
               apt:
                 name: ca-certificates
                 state: latest
-                update_cache: yes
+                update_cache: true
               register: result
               until: result is succeeded
 
@@ -221,7 +226,7 @@
                 repo: "deb https://download.ceph.com/debian-{{ ceph_release }}/ {{ ansible_facts['distribution_release'] }} main"
                 state: present
                 filename: ceph
-                update_cache: no
+                update_cache: false
 
             - name: configure Ceph testing repository
               when: ceph_origin == 'testing'
@@ -229,7 +234,7 @@
                 repo: "deb https://download.ceph.com/debian-testing/ {{ ansible_facts['distribution_release'] }} main"
                 state: present
                 filename: ceph
-                update_cache: no
+                update_cache: false
 
             - name: configure Ceph custom repositories
               when: ceph_origin == 'custom'
@@ -237,14 +242,14 @@
                 repo: "deb {{ item.baseurl }}/ {{ ansible_facts['distribution_release'] }} {{ item.components }}"
                 state: "{{ item.state | default(omit) }}"
                 filename: ceph_custom
-                update_cache: no
+                update_cache: false
               loop: "{{ ceph_custom_repositories }}"
 
         - name: install prerequisites packages
           apt:
             name: "{{ ['python3','cephadm','ceph-common'] }}"
             state: "{{ (upgrade_ceph_packages | bool) | ternary('latest', 'present') }}"
-            update_cache: yes
+            update_cache: true
           register: result
           until: result is succeeded
 
@@ -255,7 +260,7 @@
               apt:
                 name: podman
                 state: present
-                update_cache: yes
+                update_cache: true
               register: result
               until: result is succeeded
 
@@ -283,13 +288,13 @@
                     repo: "deb https://download.docker.com/linux/ubuntu {{ ansible_facts['distribution_release'] }} stable"
                     state: present
                     filename: docker
-                    update_cache: no
+                    update_cache: false
 
                 - name: install docker
                   apt:
                     name: "{{ item }}"
                     state: present
-                    update_cache: yes
+                    update_cache: true
                   register: result
                   until: result is succeeded
                   loop:


### PR DESCRIPTION
Older ceph-4 repositories removal fails on RHEL9 as ceph 4 is
not available on that version of the OS.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2250583

Also fixes ansible-lint warnings