### PR TITLE
Replace hosts: localhost by delegate_to: localhost

### DIFF
--- a/cephadm-clients.yml
+++ b/cephadm-clients.yml
@@ -26,39 +26,41 @@
 
 
 - name: Confirm local readiness
-  hosts: localhost
+  hosts: all
   gather_facts: false
   tasks:
+    - run_once: true
+      delegate_to: localhost
+      block:
+        - name: import_role ceph_defaults
+          import_role:
+            name: ceph_defaults
 
-    - name: import_role ceph_defaults
-      import_role:
-        name: ceph_defaults
+        - name: fail if the fsid parameter is missing
+          fail:
+            msg: >
+              You must supply an 'fsid' parameter for the corresponding ceph cluster
+          when: fsid is undefined
 
-    - name: fail if the fsid parameter is missing
-      fail:
-        msg: >
-          You must supply an 'fsid' parameter for the corresponding ceph cluster
-      when: fsid is undefined
+        - name: fail if admin group doesn't exist or is empty
+          fail:
+            msg: |
+              You must define a group [admin] in your inventory which provides the
+              keyring that you want to distribute
+          when: "'admin' not in groups or groups['admin'] | length < 1"
 
-    - name: fail if admin group doesn't exist or is empty
-      fail:
-        msg: |
-          You must define a group [admin] in your inventory which provides the
-          keyring that you want to distribute
-      when: "'admin' not in groups or groups['admin'] | length < 1"
+        - name: fail if client_group is NOT in the inventory
+          fail:
+            msg: >
+              Variable client_group '{{ client_group }}' is not defined in the inventory
+          when: client_group not in groups
 
-    - name: fail if client_group is NOT in the inventory
-      fail:
-        msg: >
-          Variable client_group '{{ client_group }}' is not defined in the inventory
-      when: client_group not in groups
-
-    - name: fail if keyring variable is missing
-      fail:
-        msg: |
-          You must supply a 'keyring' variable that defines the path to the key
-          that you want to distribute to your client machines
-      when: keyring is not defined
+        - name: fail if keyring variable is missing
+          fail:
+            msg: |
+              You must supply a 'keyring' variable that defines the path to the key
+              that you want to distribute to your client machines
+          when: keyring is not defined
 
 
 - name: Confirm admin host is ready

--- a/cephadm-purge-cluster.yml
+++ b/cephadm-purge-cluster.yml
@@ -13,26 +13,28 @@
 
 
 - name: check local prerequisites are in place
-  hosts: localhost
+  hosts: all
   gather_facts: false
   become: true
   any_errors_fatal: true
-
   tasks:
-    - name: fail if fsid was not provided
-      fail:
-        msg: |
-          You must provide the cluster fsid to be purged.
-          e.g. ansible-playbook -i <inventory host file> cephadm-purge-cluster.yml -e fsid=<your fsid>
-      when: fsid is undefined
 
-    - name: fail if admin group doesn't exist or is empty
-      fail:
-        msg: |
-          You must define a group [admin] in your inventory and add a node where
-          admin keyring is present at /etc/ceph/ceph.client.admin.keyring
-      when: "'admin' not in groups or groups['admin'] | length < 1"
+    - run_once: true
+      delegate_to: localhost
+      block:
+        - name: fail if fsid was not provided
+          fail:
+            msg: |
+              You must provide the cluster fsid to be purged.
+              e.g. ansible-playbook -i <inventory host file> cephadm-purge-cluster.yml -e fsid=<your fsid>
+          when: fsid is undefined
 
+        - name: fail if admin group doesn't exist or is empty
+          fail:
+            msg: |
+              You must define a group [admin] in your inventory and add a node where
+              admin keyring is present at /etc/ceph/ceph.client.admin.keyring
+          when: "'admin' not in groups or groups['admin'] | length < 1"
 
 - name: check keyring is present on the admin host
   hosts: admin[0]
@@ -96,7 +98,7 @@
 
 
 - name: confirm whether user really wants to purge the cluster
-  hosts: localhost
+  hosts: all
   gather_facts: false
   become: false
 
@@ -110,6 +112,8 @@
 
   tasks:
     - name: exit playbook, if user did not mean to purge cluster
+      run_once: true
+      delegate_to: localhost
       fail:
         msg: |
             Exiting cephadm-purge-cluster playbook, cluster was NOT purged.

--- a/rocksdb-resharding.yml
+++ b/rocksdb-resharding.yml
@@ -22,32 +22,39 @@
 # rocksdb_sharding_parameters : the rocksdb sharding parameter to set. Default is 'm(3) p(3,0-12) O(3,0-13) L P'.
 # docker : bool to be set in order to use docker engine instead. Default is False.
 
-- hosts: localhost
+- name: rocksdb-resharding
+  hosts: all
   become: true
   gather_facts: false
   tasks:
-    - name: fail if osd_id is not defined
-      fail:
-        msg: "you must provide 'osd_id' variable"
-      when: osd_id is undefined
+    - name: check prerequisites
+      run_once: true
+      delegate_to: localhost
+      block:
+        - name: fail if osd_id is not defined
+          fail:
+            msg: "you must provide 'osd_id' variable"
+          when: osd_id is undefined
 
-    - name: fail if admin_node is not defined
-      fail:
-        msg: "you must pass 'admin_node' variable"
-      when: admin_node is not defined
+        - name: fail if admin_node is not defined
+          fail:
+            msg: "you must pass 'admin_node' variable"
+          when: admin_node is not defined
+
+        - name: fail if osd_id isn't an id
+          fail:
+            msg: "osd_id must be an id"
+          when: not osd_id is regex('^\d+$')
+
+        - name: set_fact cephadm_cmd
+          set_fact:
+            cephadm_cmd: "cephadm {{ '--docker' if docker | default(False) | bool else '' }} shell ceph"
+
 
     - name: test connectivity to admin node
       ping:
       delegate_to: "{{ admin_node }}"
-
-    - name: fail if osd_id isn't an id
-      fail:
-        msg: "osd_id must be an id"
-      when: not osd_id is regex('^\d+$')
-
-    - name: set_fact cephadm_cmd
-      set_fact:
-        cephadm_cmd: "cephadm {{ '--docker' if docker | default(False) | bool else '' }} shell ceph"
+      run_once: true
 
     - name: get details about the osd daemon
       delegate_to: "{{ admin_node }}"
@@ -89,6 +96,7 @@
 
     - name: resharding operations
       delegate_to: "{{ container_host }}"
+      run_once: true
       block:
         - name: check fs consistency with fsck before resharding
           command: "{{ ceph_bluestore_tool_cmd }} fsck"

--- a/tox.ini
+++ b/tox.ini
@@ -88,7 +88,7 @@ commands=
   ansible-playbook -vv -i {changedir}/hosts {toxinidir}/rocksdb-resharding.yml -e fsid=4217f198-b8b7-11eb-941d-5254004b7a69 -e osd_id=0 -e admin_node=ceph-node0
 
   # Purge the cluster
-  ansible-playbook -vv -i {changedir}/hosts {toxinidir}/cephadm-purge-cluster.yml -e ireallymeanit=yes -e fsid=4217f198-b8b7-11eb-941d-5254004b7a69
+  ansible-playbook -vv -i {changedir}/hosts -l ceph_cluster {toxinidir}/cephadm-purge-cluster.yml -e ireallymeanit=yes -e fsid=4217f198-b8b7-11eb-941d-5254004b7a69
 
   py.test -n 8 --durations=0 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts --ssh-config={changedir}/vagrant_ssh_config {changedir}/tests/test_purge.py
 

--- a/validate/insecure-registries.yml
+++ b/validate/insecure-registries.yml
@@ -3,11 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # Author: Guillaume Abrioux <gabrioux@redhat.com>
 
-- hosts: localhost
+- name: insecure_registries
+  hosts: all
   become: false
   gather_facts: false
   tasks:
     - name: fail if insecure_registry is undefined
+      run_once: true
+      delegate_to: localhost
       fail:
         msg: "'insecure_registry' is undefined, it must be set when 'set_insecure_registries' is 'true'."
       when:

--- a/validate/preflight.yml
+++ b/validate/preflight.yml
@@ -6,29 +6,33 @@
 - ansible.builtin.import_playbook: insecure-registries.yml
   when: set_insecure_registries | default(false) | bool
 
-- hosts: localhost
+- name: preflight
+  hosts: all
   become: false
   gather_facts: false
   tasks:
-    - name: import_role ceph_defaults
-      import_role:
-        name: ceph_defaults
+    - run_once: true
+      delegate_to: localhost
+      block:
+        - name: import_role ceph_defaults
+          import_role:
+            name: ceph_defaults
 
-    - name: fail when ceph_origin is custom with no repository defined
-      fail:
-        msg: "You must define 'ceph_custom_repositories' or 'custom_repo_url' when ceph_origin is 'custom'"
-      when:
-        - ceph_origin == 'custom'
-        - (custom_repo_url is undefined or custom_repo_url == '')
-        - ceph_custom_repositories is undefined
+        - name: fail when ceph_origin is custom with no repository defined
+          fail:
+            msg: "You must define 'ceph_custom_repositories' or 'custom_repo_url' when ceph_origin is 'custom'"
+          when:
+            - ceph_origin == 'custom'
+            - (custom_repo_url is undefined or custom_repo_url == '')
+            - ceph_custom_repositories is undefined
 
-    - name: fail if baseurl is not defined for ceph_custom_repositories
-      fail:
-        msg: "One repository is missing a required parameter: name, description, baseurl."
-      loop: "{{ ceph_custom_repositories }}"
-      when:
-        - ceph_origin == 'custom'
-        - ceph_custom_repositories is defined
-        - (item.baseurl is undefined
-          or item.name is undefined
-          or item.description is undefined)
+        - name: fail if baseurl is not defined for ceph_custom_repositories
+          fail:
+            msg: "One repository is missing a required parameter: name, description, baseurl."
+          loop: "{{ ceph_custom_repositories }}"
+          when:
+            - ceph_origin == 'custom'
+            - ceph_custom_repositories is defined
+            - (item.baseurl is undefined
+              or item.name is undefined
+              or item.description is undefined)


### PR DESCRIPTION
As some users have inventory files with not just ceph hosts, they uses --limit to target only ceph nodes.
Using "hosts: localhost" in playbooks prevent those tasks being executed. Using delegate_to with run_once fixes the issue.

Fixes: https://github.com/ceph/cephadm-ansible/issues/170