### PR TITLE
Implement diff in ceph_orch_apply.py

### DIFF
--- a/library/ceph_orch_apply.py
+++ b/library/ceph_orch_apply.py
@@ -82,7 +82,10 @@ def retrieve_current_spec(module: AnsibleModule, expected_spec: Dict) -> Dict:
     """ retrieve current config of the service """
     service: str = expected_spec["service_type"]
     cmd = build_base_cmd_orch(module)
-    cmd.extend(['ls', service, '--format=yaml'])
+    cmd.extend(['ls', service])
+    if 'service_name' in expected_spec:
+        cmd.extend([expected_spec["service_name"]])
+    cmd.extend(['--format=yaml'])
     out = module.run_command(cmd)
     if isinstance(out, str):
         # if there is no existing service, cephadm returns the string 'No services reported'


### PR DESCRIPTION
Hello,

Dynamic attributes breaking idempotency will be added when fetching the current orch spec from a running cluster. This simple PR remove these attributes before comparing the current and the expected spec and also implement diff mode. This will help users build idempotents roles and playbooks.

Best Regards.