### PR TITLE
tox: remove CentOS 8 from the available testing scenarios

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
   flake8,mypy,unittests
-  {el8,el9,rocky8,rocky9,ubuntu_lts}-{functional}
+  {el9,rocky8,rocky9,ubuntu_lts}-{functional}
 skipsdist = True
 
 [testenv:mypy]
@@ -28,7 +28,7 @@ setenv=
   PYTHONPATH = {env:PYTHONPATH:}:{toxinidir}/library:{toxinidir}/module_utils:{toxinidir}/tests/library
 commands = py.test -vvv -n=auto {toxinidir}/tests/library/ {toxinidir}/tests/module_utils
 
-[testenv:{el8,el9,rocky8,rocky9,ubuntu_lts}-functional]
+[testenv:{el9,rocky8,rocky9,ubuntu_lts}-functional]
 allowlist_externals =
     vagrant
     bash
@@ -37,7 +37,6 @@ passenv=*
 sitepackages=True
 setenv=
   # Set the vagrant box image to use
-  el8: CEPH_ANSIBLE_VAGRANT_BOX = centos/stream8
   el9: CEPH_ANSIBLE_VAGRANT_BOX = centos/stream9
   rocky8: CEPH_ANSIBLE_VAGRANT_BOX = generic/rocky8
   rocky9: CEPH_ANSIBLE_VAGRANT_BOX = generic/rocky9


### PR DESCRIPTION
Due to CentOS 8 eol on May 31, 2024*, CentOS 8 is removed as a testing scenario OS

*https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/