### PR TITLE
Fix prerequisites in cephadm-preflight

### DIFF
--- a/ceph_defaults/defaults/main.yml
+++ b/ceph_defaults/defaults/main.yml
@@ -20,5 +20,6 @@ ceph_client_pkgs:
 infra_pkgs:
   - chrony
   - podman
+  - lvm2
   - sos
 client_group: clients

--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -171,7 +171,7 @@
               command: dnf config-manager --set-enabled "{{ 'powertools' if ansible_facts['distribution_major_version'] == '8' else 'crb' }}"
               changed_when: false
 
-            - name: install package
+            - name: install epel package
               package:
                 name: epel-release
                 state: present
@@ -205,7 +205,7 @@
             state: "{{ (upgrade_ceph_packages | bool) | ternary('latest', 'present') }}"
           register: result
           until: result is succeeded
-          when: group_names == [client_group]
+          when: client_group in group_names
 
 
         - name: ensure chronyd is running


### PR DESCRIPTION
I noticed that clients configured with cephadm-preflight.yml were not getting prerequisite packages installed. This was due to a wrong conditional in the playbook.

Also lvm2 is [an official prerequisite as per the docs](https://docs.ceph.com/en/quincy/cephadm/install/#requirements) so I added it to the infra packages in the defaults as not all distros in all feature-flavors come with it installed.

There is still the problem, that the clients group is left untouched by the preflight playbook. This is also fixed my this PR.
Here a comparison in playbook runs. Here rocky9-01 is admin, but not client and osd. The rest (02-04) is admin, client and osd.

## existing prefligt playbook

```
TASK [install prerequisites packages on servers]
ok: [rocky9-01.testcluster.local]                     
changed: [rocky9-03.testcluster.local]                
changed: [rocky9-02.testcluster.local]                
changed: [rocky9-04.testcluster.local]                
                                                
TASK [install prerequisites packages on clients]
skipping: [rocky9-01.testcluster.local]               
skipping: [rocky9-02.testcluster.local]               
skipping: [rocky9-03.testcluster.local]               
skipping: [rocky9-04.testcluster.local]                  
```

As you can see, the clients are skipped, no packages are installed.

## proposed preflight playbook

```
TASK [install prerequisites packages on servers]
changed: [rocky9-04.testcluster.local]                
changed: [rocky9-03.testcluster.local]                
changed: [rocky9-01.testcluster.local]                
changed: [rocky9-02.testcluster.local]                
                                                
TASK [install prerequisites packages on clients]
skipping: [rocky9-01.testcluster.local]               
ok: [rocky9-04.testcluster.local]                     
ok: [rocky9-02.testcluster.local]                     
ok: [rocky9-03.testcluster.local]                     
```

The clients are now not immediately skipped anymore and the required packages are installed.