### PR TITLE
replace character u-2013 with hyphen

### DIFF
--- a/library/cephadm_bootstrap.py
+++ b/library/cephadm_bootstrap.py
@@ -87,7 +87,7 @@ options:
         default: true
     allow_overwrite:
         description:
-            - allow overwrite of existing –output-* config/keyring/ssh files.
+            - allow overwrite of existing -output-* config/keyring/ssh files.
         required: false
         default: false
     registry_url:


### PR DESCRIPTION
`U+2013` was replaced with `U+002D` to avoid any unexpected behavior.
Ref: https://www.compart.com/en/unicode/category/Pd