### PR TITLE
Fix issue 2351790: Modify firewalld check

### DIFF
--- a/checks.yml
+++ b/checks.yml
@@ -68,7 +68,6 @@
       and (podman_version.split('.')[0] | int > 3
       or (podman_version.split('.')[0] | int == 3
       and podman_version.split('.')[1] | int >= 3))) else 'FAIL' }}
-
     podman_reason: >-
       {{ 'Podman is not installed, required for Ceph'
       if 'podman' not in ansible_facts.packages else
@@ -119,7 +118,6 @@
       cores:
         result: "{{ 'PASS' if ansible_facts['processor_vcpus'] | int >= 4 else 'FAIL' }}"
         reason: "{{ 'System has only ' ~ ansible_facts['processor_vcpus'] ~ ' cores, required: 4' if ansible_facts['processor_vcpus'] | int < 4 else 'N/A' }}"
-
     memory_checks:
       ram:
         result: "{{ 'PASS' if ansible_facts['memtotal_mb'] | int >= 8192 else 'FAIL' }}"
@@ -134,7 +132,6 @@
           {{ 'System has only ' ~ ansible_facts['swaptotal_mb'] ~
           ' MB Swap, required: ' ~ ((ansible_facts['memtotal_mb'] * 1.5) | round) | int ~ ' MB'
           if ansible_facts['swaptotal_mb'] | int < ((ansible_facts['memtotal_mb'] * 1.5) | round) | int else 'N/A' }}
-
     filesystem_checks:
       var_partition:
         result: "{{ 'PASS' if (ansible_facts['mounts'] | selectattr('mount', 'equalto', '/var') | list | length > 0) else 'FAIL' }}"
@@ -180,8 +177,15 @@
       {'Check': 'OS Version', 'Result': os_check, 'Reason': os_reason},
       {'Check': 'Tuned Profile', 'Result': tuned_profile_check, 'Reason': tuned_profile_reason},
       {'Check': 'RHEL Profile', 'Result': rhel_profile_check, 'Reason': rhel_profile_reason},
-      {'Check': 'Firewalld Running', 'Result': ('PASS' if firewall_status.status.ActiveState == 'active' else 'FAIL'),
-      'Reason': ('Firewalld was not running and could not be started' if firewall_status.failed else 'N/A')},
+      {'Check': 'Firewalld Running',
+       'Result': ('PASS' if firewall_status.get('status', {}).get('ActiveState', 'unknown') == 'active'
+                  else 'FAIL'),
+       'Reason': ('Firewalld service is missing' if 'msg' in firewall_status
+                  else ('Firewalld is stopped. Start it using systemctl start firewalld'
+                        if firewall_status.get('status', {}).get('ActiveState') == 'inactive'
+                        else ('Firewalld was not running and could not be started'
+                              if firewall_status.get('failed', False)
+                              else 'Unexpected issue, check systemctl status firewalld')))},
       {'Check': 'Podman Installed', 'Result': podman_check, 'Reason': podman_reason},
       {'Check': 'SELinux', 'Result': selinux_check, 'Reason': selinux_reason},
       {'Check': 'Required Packages Installed', 'Result': package_check, 'Reason': package_reason},


### PR DESCRIPTION
Fixes: 
https://bugzilla.redhat.com/show_bug.cgi?id=2351790
https://tracker.ceph.com/issues/70525

Description of problem:
========================
cephadm-preflight playbook is failing at the "Store All Preflight Check Results
```

Error:
*********
TASK [Store all preflight check results] *****************************************************************************************************************************************************************************************************
Wednesday 12 March 2025  16:19:43 +0000 (0:00:00.068)       0:00:08.637 ******* 
fatal: [10.0.215.50]: FAILED! => 
  msg: |-
    The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'status'. 'dict object' has no attribute 'status'
  
    The error appears to be in '/usr/share/cephadm-ansible/checks.yml': line 177, column 3, but may
    be elsewhere in the file depending on the exact syntax problem.
  
    The offending line appears to be:
  
  
    - name: Store all preflight check results
      ^ here
```

