### PR TITLE
Handle missing firewalld gracefully in preflight check

### DIFF
--- a/checks.yml
+++ b/checks.yml
@@ -213,7 +213,9 @@
       (['RHEL Profile'] if rhel_profile_check == 'FAIL' else []) +
       (['SELinux'] if selinux_check == 'FAIL' else []) +
       (['Required Packages'] if package_check == 'FAIL' else preflight_failures) +
-      (['Firewalld Running'] if firewall_status.status.ActiveState != 'active' else []) +
+      (['Firewalld Running']
+       if firewall_status.get('status', {}).get('ActiveState') != 'active'
+       else []) +
       (['Podman Installed'] if podman_check == 'FAIL' else []) +
       (['Minimum RAM'] if memory_checks['ram']['result'] == 'FAIL' else []) +
       (['Swap Space'] if memory_checks['swap']['result'] == 'FAIL' else []) +


### PR DESCRIPTION
Handle missing firewalld gracefully in preflight check

**Description of the problem:**

The playbook previously failed when the firewalld service was not installed or active on the host, due to unguarded access to the 'status' attribute:

**Error:**
TASK [Store all preflight check results]
fatal: [10.0.215.50]: FAILED! =>
  msg: |-
    The task includes an option with an undefined variable. The error was:
    'dict object' has no attribute 'status'. 'dict object' has no attribute 'status'

This commit updates the Firewalld preflight check to safely handle missing or inactive firewalld service scenarios.

Fixes: https://tracker.ceph.com/issues/70702