### PR TITLE
feat: add support for `ceph config-key`

### DIFF
--- a/plugins/modules/ceph_config_key.py
+++ b/plugins/modules/ceph_config_key.py
@@ -1,0 +1,159 @@
+from __future__ import absolute_import, division, print_function
+from typing import Any, Dict, List, Tuple, Union
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule  # type: ignore
+try:
+    from ansible.module_utils.ceph_common import exit_module, build_base_cmd_shell, fatal  # type: ignore
+except ImportError:
+    from module_utils.ceph_common import exit_module, build_base_cmd_shell, fatal  # type: ignore
+
+import datetime
+import json
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: ceph_config_key
+short_description: get/set ceph config-key
+version_added: ""
+description:
+    - Set Ceph config key options.
+options:
+    fsid:
+        type: str
+        description:
+            - the fsid of the Ceph cluster to interact with.
+        required: false
+    image:
+        type: str
+        description:
+            - The Ceph container image to use.
+        required: false
+    action:
+        type: str
+        description:
+            - whether to get or set the parameter specified in 'option'
+        required: false
+        default: 'set'
+    option:
+        type: str
+        description:
+            - name of the parameter to be set
+        required: true
+    value:
+        type: str
+        description:
+            - value of the parameter
+        required: true if action is 'set'
+
+'''
+
+EXAMPLES = '''
+- name: get config/mgr/mgr/prometheus/scrape_interval
+  ceph_config_key:
+    action: get
+    option: config/mgr/mgr/prometheus/scrape_interval
+
+- name: set config/mgr/mgr/prometheus/scrape_interval to 15s
+  ceph_config_key:
+    action: set
+    option: config/mgr/mgr/prometheus/scrape_interval
+    value: 15
+
+- name: set mgr/cephadm/services/prometheus/prometheus.yml from file
+  ceph_config_key:
+    action: set
+    option: mgr/cephadm/services/prometheus/prometheus.yml
+    value: '{{lookup("file","/path/to/prometheus.yml")}}'
+'''
+
+RETURN = '''#  '''
+
+
+def set_config_key_value(module: "AnsibleModule",
+                         option: str,
+                         value: str) -> Tuple[int, List[str], str, str]:
+    cmd = build_base_cmd_shell(module)
+    cmd.extend(['ceph', 'config-key', 'set', option, '-i', '-'])
+
+    # pass the value through stdin to avoid issues with multi-line values, encoding, etc.
+    rc, out, err = module.run_command(args=cmd, data=value)
+
+    return rc, cmd, out.strip(), err
+
+
+def get_config_key_dump(module: "AnsibleModule") -> Tuple[int, List[str], str, str]:
+    cmd = build_base_cmd_shell(module)
+    cmd.extend(['ceph', 'config-key', 'dump', '--format', 'json'])
+    rc, out, err = module.run_command(cmd)
+    if rc:
+        fatal(message=f"Can't get current configuration via `ceph config-key dump`.Error:\n{err}", module=module)
+    out = out.strip()
+    return rc, cmd, out, err
+
+
+def get_config_key_current_value(option: str, config_dump: Dict[str, Any]) -> Union[str, None]:
+    for key in config_dump:
+        if key == option:
+            return config_dump[key]
+    return None
+
+
+def main() -> None:
+    module = AnsibleModule(
+        argument_spec=dict(
+            action=dict(type='str', required=False, choices=['get', 'set'], default='set'),
+            option=dict(type='str', required=False),
+            value=dict(type='str', required=False),
+            fsid=dict(type='str', required=False),
+            image=dict(type='str', required=False)
+        ),
+        supports_check_mode=True,
+        required_if=[['action', 'set', ['value']]]
+    )
+
+    # Gather module parameters in variables
+    option = module.params.get('option')
+    value = module.params.get('value')
+    action = module.params.get('action')
+
+    startd = datetime.datetime.now()
+    changed = False
+
+    # getting the value via a dump simplifies checking whether the value is currently set
+    rc, cmd, dumpout, err = get_config_key_dump(module)
+    config_dump = json.loads(dumpout)
+    current_value = get_config_key_current_value(option, config_dump)
+    diff = None
+    out = ''
+
+    if action == 'set':
+        if value is None:
+            module.fail_json(msg="Value is required when action is set")
+        elif value == current_value:
+            out = 'option={} already set. Skipping.'.format(option)
+        else:
+            changed = True
+            diff = dict(before=current_value, after=value)
+            if not module.check_mode:
+                rc, cmd, out, err = set_config_key_value(module, option, value)
+    else:
+        if current_value is None:
+            out = ''
+            err = 'No value found for option={}'.format(option)
+        else:
+            out = current_value
+
+    exit_module(module=module, out=out, rc=rc,
+                cmd=cmd, err=err, startd=startd,
+                changed=changed, diff=diff)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/library/test_ceph_config_key.py
+++ b/tests/library/test_ceph_config_key.py
@@ -1,0 +1,163 @@
+from mock.mock import patch
+import pytest
+import common
+import ceph_config_key
+
+
+class TestCephConfigKey(object):
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_set_config_key(self, m_run_command, m_exit_json):
+        """
+        Test setting a config key value
+        """
+        common.set_module_args({
+            'action': 'set',
+            'option': 'config/mgr/mgr/prometheus/scrape_interval',
+            'value': '15'
+        })
+        m_exit_json.side_effect = common.exit_json
+
+        # Mock the config-key dump response
+        m_run_command.side_effect = [
+            (0, '{"config/mgr/mgr/prometheus/scrape_interval": "10"}', ''),  # dump response
+            (0, '', '')  # set response
+        ]
+
+        with pytest.raises(common.AnsibleExitJson) as result:
+            ceph_config_key.main()
+
+        result = result.value.args[0]
+        assert result['changed'] is True
+        assert result['cmd'] == ['cephadm',
+                                 'shell',
+                                 'ceph',
+                                 'config-key',
+                                 'set',
+                                 'config/mgr/mgr/prometheus/scrape_interval',
+                                 '-i',
+                                 '-']
+        assert result['diff'] == {'before': '10', 'after': '15'}
+        assert result['stdout'] == ''
+        assert result['stderr'] == ''
+        assert result['rc'] == 0
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_set_config_key_idempotent(self, m_run_command, m_exit_json):
+        """
+        Test setting a config key value that's already set
+        """
+        common.set_module_args({
+            'action': 'set',
+            'option': 'config/mgr/mgr/prometheus/scrape_interval',
+            'value': '15'
+        })
+        m_exit_json.side_effect = common.exit_json
+
+        # Mock the config-key dump response
+        m_run_command.return_value = (0, '{"config/mgr/mgr/prometheus/scrape_interval": "15"}', '')
+
+        with pytest.raises(common.AnsibleExitJson) as result:
+            ceph_config_key.main()
+
+        result = result.value.args[0]
+        assert not result['changed']
+        assert result['stdout'] == 'option=config/mgr/mgr/prometheus/scrape_interval already set. Skipping.'
+        assert result['stderr'] == ''
+        assert result['rc'] == 0
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_get_config_key(self, m_run_command, m_exit_json):
+        """
+        Test getting a config key value
+        """
+        common.set_module_args({
+            'action': 'get',
+            'option': 'config/mgr/mgr/prometheus/scrape_interval'
+        })
+        m_exit_json.side_effect = common.exit_json
+
+        # Mock the config-key dump response
+        m_run_command.return_value = (0, '{"config/mgr/mgr/prometheus/scrape_interval": "15"}', '')
+
+        with pytest.raises(common.AnsibleExitJson) as result:
+            ceph_config_key.main()
+
+        result = result.value.args[0]
+        assert not result['changed']
+        assert result['stdout'] == '15'
+        assert result['stderr'] == ''
+        assert result['rc'] == 0
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_get_config_key_nonexistent(self, m_run_command, m_exit_json):
+        """
+        Test getting a config key that doesn't exist
+        """
+        common.set_module_args({
+            'action': 'get',
+            'option': 'nonexistent/key'
+        })
+        m_exit_json.side_effect = common.exit_json
+
+        # Mock the config-key dump response
+        m_run_command.return_value = (0, '{}', '')
+
+        with pytest.raises(common.AnsibleExitJson) as result:
+            ceph_config_key.main()
+
+        result = result.value.args[0]
+        assert not result['changed']
+        assert result['stdout'] == ''
+        assert result['stderr'] == 'No value found for option=nonexistent/key'
+        assert result['rc'] == 0
+
+    @patch('ansible.module_utils.basic.AnsibleModule.exit_json')
+    @patch('ansible.module_utils.basic.AnsibleModule.run_command')
+    def test_set_config_key_check_mode(self, m_run_command, m_exit_json):
+        """
+        Test setting a config key in check mode
+        """
+        common.set_module_args({
+            'action': 'set',
+            'option': 'config/mgr/mgr/prometheus/scrape_interval',
+            'value': '15',
+            '_ansible_check_mode': True
+        })
+        m_exit_json.side_effect = common.exit_json
+
+        # Mock the config-key dump response
+        m_run_command.return_value = (0, '{"config/mgr/mgr/prometheus/scrape_interval": "10"}', '')
+
+        with pytest.raises(common.AnsibleExitJson) as result:
+            ceph_config_key.main()
+
+        result = result.value.args[0]
+        assert result['changed']
+        assert result['diff'] == {'before': '10', 'after': '15'}
+        # Verify no set command was actually run
+        assert m_run_command.call_count == 1  # only the dump command was called
+        assert result['stdout'] == ''
+        assert result['stderr'] == ''
+        assert result['rc'] == 0
+
+    @patch('ansible.module_utils.basic.AnsibleModule.fail_json')
+    def test_set_config_key_missing_value(self, m_fail_json):
+        """
+        Test setting a config key without providing a value
+        """
+        common.set_module_args({
+            'action': 'set',
+            'option': 'config/mgr/mgr/prometheus/scrape_interval'
+        })
+        m_fail_json.side_effect = common.fail_json
+
+        with pytest.raises(common.AnsibleFailJson) as result:
+            ceph_config_key.main()
+
+        result = result.value.args[0]
+        assert result['msg'] == 'action is set but all of the following are missing: value'


### PR DESCRIPTION
`ceph config-key` is useful to be able to configure services, such as setting prometheus.yml config.

Fixes #338 