### PR TITLE
Use a user-writable directory for storing playbook summary reports

### DIFF
--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -42,6 +42,8 @@
       - ceph-radosgw
       - rbd-mirror
 
+    reports_dir: "{{ lookup('env', 'HOME') }}/cephadm-reports"
+
   tasks:
     - name: Import_role ceph_defaults
       ansible.builtin.import_role:

--- a/checks.yml
+++ b/checks.yml
@@ -230,7 +230,7 @@
 
 - name: Ensure reports directory exists on the Ansible controller
   ansible.builtin.file:
-    path: ./reports
+    path: "{{ reports_dir }}"
     state: directory
     mode: '0755'
   delegate_to: localhost
@@ -240,7 +240,7 @@
 - name: Generate preflight check report file per node
   ansible.builtin.template:
     src: preflight_report.j2
-    dest: "./reports/{{ inventory_hostname }}_preflight_report.txt"
+    dest: "{{ reports_dir }}/{{ inventory_hostname }}_preflight_report.txt"
     mode: '0644'
   delegate_to: localhost
   run_once: false
@@ -252,7 +252,7 @@
 
 - name: Show path where the preflight report is saved
   ansible.builtin.debug:
-    msg: "Preflight report saved at: {{ playbook_dir }}/reports/{{ inventory_hostname }}_preflight_report.txt"
+    msg: "Preflight report saved at: {{ reports_dir }}/{{ inventory_hostname }}_preflight_report.txt"
   delegate_to: localhost
   run_once: false
   become: false


### PR DESCRIPTION
Use a user-writable directory for storing playbook summary reports

Problem Description:

The preflight playbook failed when executed by non-root users due to permission errors while creating or writing to the ./reports directory. Since the playbook runs from a system-owned location (/usr/share/cephadm-ansible), the relative path ./reports was not writable by users like cephuser, causing the tasks that generate and store summary reports to fail.

This commit replaces the hardcoded ./reports path with a user-writable directory, defaulting to $HOME/cephadm-reports, by introducing the reports_dir variable.

Fixes: https://tracker.ceph.com/issues/71054