### PR TITLE
tests: make host label check tolerant to extra labels

### DIFF
--- a/tests/functional/tests/test_cluster.py
+++ b/tests/functional/tests/test_cluster.py
@@ -11,4 +11,4 @@ class TestCluster(object):
 
         for h in self.host_ls:
             name = h['hostname']
-            assert sorted(inventory_variables[name]['labels']) == sorted(h['labels'])
+            assert all(item in h['labels'] for item in inventory_variables[name]['labels'])


### PR DESCRIPTION
this fixes functional test failure where inventory contains additional labels (eg: '_no_conf_keyring', '_no_schedule') not listed in test expectations.

the idea is to update assertion to verify that all expected labels are present instead of requiring an exact match.