### PR TITLE
Add warning if swap is enabled on nodes

### DIFF
--- a/checks.yml
+++ b/checks.yml
@@ -125,13 +125,14 @@
           {{ 'System has only ' ~ ansible_facts['memtotal_mb'] ~
           ' MB RAM, required: 8192MB' if ansible_facts['memtotal_mb'] | int < 8192 else 'N/A' }}
       swap:
-        required: "{{ ((ansible_facts['memtotal_mb'] | int * 1.5) | round) | int }}"
         actual: "{{ ansible_facts['swaptotal_mb'] | int }}"
-        result: "{{ 'PASS' if (ansible_facts['swaptotal_mb'] | int) >= ((ansible_facts['memtotal_mb'] * 1.5) | round) | int else 'FAIL' }}"
+        result: >-
+          {{ 'WARN' if (ansible_facts['swaptotal_mb'] | int) > 0 else 'PASS' }}
         reason: >-
-          {{ 'System has only ' ~ ansible_facts['swaptotal_mb'] ~
-          ' MB Swap, required: ' ~ ((ansible_facts['memtotal_mb'] * 1.5) | round) | int ~ ' MB'
-          if ansible_facts['swaptotal_mb'] | int < ((ansible_facts['memtotal_mb'] * 1.5) | round) | int else 'N/A' }}
+          {{ 'Swap is enabled (' ~ ansible_facts['swaptotal_mb'] ~ ' MB). It is recommended to disable swap on OSD nodes for optimal performance.'
+             if (ansible_facts['swaptotal_mb'] | int) > 0
+             else 'Swap is disabled (recommended for OSD nodes).' }}
+
     filesystem_checks:
       var_partition:
         result: "{{ 'PASS' if (ansible_facts['mounts'] | selectattr('mount', 'equalto', '/var') | list | length > 0) else 'FAIL' }}"
@@ -190,7 +191,7 @@
       {'Check': 'SELinux', 'Result': selinux_check, 'Reason': selinux_reason},
       {'Check': 'Required Packages Installed', 'Result': package_check, 'Reason': package_reason},
       {'Check': 'Minimum RAM (8GB)', 'Result': memory_checks['ram']['result'], 'Reason': memory_checks['ram']['reason']},
-      {'Check': 'Swap Space (1.5x RAM)', 'Result': memory_checks['swap']['result'], 'Reason': memory_checks['swap']['reason']},
+      {'Check': 'Swap Space', 'Result': memory_checks['swap']['result'], 'Reason': memory_checks['swap']['reason']},
       {'Check': 'CPU x86-64-v2', 'Result': cpu_checks['x86_64_v2']['result'], 'Reason': cpu_checks['x86_64_v2']['reason']},
       {'Check': 'CPU Cores >= 4', 'Result': cpu_checks['cores']['result'], 'Reason': cpu_checks['cores']['reason']},
       {'Check': '/var is a separate partition', 'Result': filesystem_checks['var_partition']['result'], 'Reason': filesystem_checks['var_partition']['reason']},
@@ -218,7 +219,6 @@
        else []) +
       (['Podman Installed'] if podman_check == 'FAIL' else []) +
       (['Minimum RAM'] if memory_checks['ram']['result'] == 'FAIL' else []) +
-      (['Swap Space'] if memory_checks['swap']['result'] == 'FAIL' else []) +
       (['CPU x86-64-v2'] if cpu_checks['x86_64_v2']['result'] == 'FAIL' else []) +
       (['CPU Cores'] if cpu_checks['cores']['result'] == 'FAIL' else []) +
       (['/var Partition'] if filesystem_checks['var_partition']['result'] == 'FAIL' else []) +

--- a/templates/preflight_report.j2
+++ b/templates/preflight_report.j2
@@ -5,9 +5,9 @@
  System Checks
 --------------------------------------------------
 {% for item in preflight_results %}
-- {{ item['Check'] }}: {% if item['Result'] == 'PASS' %}✅ Passed{% elif item['Result'] == 'FAIL' %}❌ Failed{% else %}ℹ️ INFO{% endif %}
+- {{ item['Check'] }}: {% if item['Result'] == 'PASS' %}✅ Passed{% elif item['Result'] == 'FAIL' %}❌ Failed{% elif item['Result'] == 'WARN' %}⚠️ Warning{% else %}ℹ️ INFO{% endif %}
 
-{% if item['Result'] == 'FAIL' or item['Result'] == 'INFO' %}
+{% if item['Result'] in ['FAIL', 'WARN', 'INFO'] %}
     - Reason: {{ item['Reason'] }}
 {% endif %}
 


### PR DESCRIPTION
The current preflight report and its associated documentation recommend configuring swap space on all Ceph nodes. This recommendation is dangerous and misleading, as enabling swap on Ceph cluster nodes—particularly OSD node has been shown to cause severe performance degradation and even cluster outages in real-world deployments.

(Reference: https://access.redhat.com/solutions/7127163)

Therefore, the preflight check should not encourage or validate the presence of swap; instead, it should:
    Warn when swap is detected, explicitly stating that swap must be disabled on OSD nodes.

Fixes: https://tracker.ceph.com/issues/73667

Logs:

```
TASK [Show Preflight Check Report] *********************************************************************************************************************************************************************************************************************************************
ok: [rhel-ceph-admin] => 
  msg: |-
    ==================================================
                   **  Preflight Check Report **
    ==================================================
  
     System Checks
    --------------------------------------------------
    - OS Version: ✅ Passed
  
    - Tuned Profile: ❌ Failed
        - Reason: Incorrect tuned profile. Expected: throughput-performance
  
    - RHEL Profile: ❌ Failed
        - Reason: Incorrect RHEL software profile. Expected: Server with File and Storage Server.
  
    - Firewalld Running: ✅ Passed
  
    - Podman Installed: ✅ Passed
  
    - SELinux: ✅ Passed
  
    - Required Packages Installed: ❌ Failed
        - Reason: Missing packages: rpcbind
  
    - Minimum RAM (8GB): ❌ Failed
        - Reason: System has only 7680 MB RAM, required: 8192MB
  
    - Swap Space: ⚠️ Warning
        - Reason: Swap is enabled (8067 MB). It is recommended to disable swap on OSD nodes for optimal performance.
  
    - CPU x86-64-v2: ✅ Passed
  
    - CPU Cores >= 4: ✅ Passed
  
    - /var is a separate partition: ❌ Failed
        - Reason: /var is not a separate partition
  
    - Root Filesystem >= 100GB: ❌ Failed
        - Reason: Root FS is only 69GB, required: 100GB
  
    - NIC Configuration: ℹ️ INFO
        - Reason: Available network interfaces: enp1s0 | Speeds (Mbps): -1
  
    - Jumbo Frames Enabled: ❌ Failed
        - Reason: MTU is 1500, recommended > 1500
  
    - NIC Static IP Configuration: ❌ Failed
        - Reason: NIC is using DHCP, static IP is recommended
  
    - NIC Bandwidth (10GbE Recommended): ❌ Failed
        - Reason: NIC speed is -1 Mbps, recommended is 10GbE
  
    - Network Latency: ℹ️ INFO
        - Reason: Average latency (ms): ['']
  
    ==================================================
    ** Summary **
    --------------------------------------------------
    ℹ️  The following checks did not meet the recommended configuration:
  
       - Tuned Profile
       - RHEL Profile
       - Required Packages
       - Minimum RAM
       - /var Partition
       - Root Filesystem
       - Jumbo Frames Enabled
       - NIC Static IP Configuration
       - NIC Bandwidth
  
       These values differ from expected baselines and may impact Ceph performance.
       Please review and adjust the system configuration.

TASK [Show path where the preflight report is saved] ***************************************************************************************************************************************************************************************************************************
ok: [rhel-ceph-admin -> localhost] => 
  msg: 'Preflight report saved at: /home/kushaldeb/cephadm-reports/rhel-ceph-admin_preflight_report.txt'

```