### PR TITLE
playbooks: fix a bug in cephadm-distribute-ssh-key

### DIFF
--- a/cephadm-distribute-ssh-key.yml
+++ b/cephadm-distribute-ssh-key.yml
@@ -53,7 +53,7 @@
           delegate_to: localhost
           when:
             - not cephadm_pubkey_path_stat.stat.exists | bool
-              or not cephadm_pubkey_path_stat.stat.isfile | bool
+              or not cephadm_pubkey_path_stat.stat.isreg | bool
 
     - name: Get the cephadm ssh pub key
       ansible.builtin.command: "cephadm shell {{ '--fsid ' + fsid if fsid is defined else '' }} ceph cephadm get-pub-key"


### PR DESCRIPTION
The stat module does not expose an `isfile` attribute. Let's use `stat.isreg` attribute to test for a regular file.