### PR TITLE
Fix preflight check failure caused by incorrect ansible_facts lookup …

### DIFF
--- a/checks.yml
+++ b/checks.yml
@@ -198,7 +198,9 @@
       {'Check': 'Root Filesystem >= 100GB', 'Result': filesystem_checks['root_fs']['result'], 'Reason': filesystem_checks['root_fs']['reason']},
       {'Check': 'NIC Configuration', 'Result': 'INFO',
       'Reason': 'Available network interfaces: ' ~ (network_interfaces | default([]) | join(', ')) ~
-              ' | Speeds (Mbps): ' ~ (network_interfaces | default([]) | map('extract', ansible_facts) | map(attribute='speed') | list | join(', '))},
+              ' | Speeds (Mbps): ' ~
+              (network_interfaces | map('replace','-','_') | map('regex_replace','^','ansible_') |
+              map('extract', hostvars[inventory_hostname].ansible_facts) | map(attribute='speed', default='-1') | list | join(', '))},
       {'Check': 'Jumbo Frames Enabled', 'Result': ('PASS' if (primary_mtu | int) > 1500 else 'FAIL'),
       'Reason': ('MTU is ' ~ (primary_mtu | int) ~ ', recommended > 1500' if (primary_mtu | int) <= 1500 else 'N/A')},
       {'Check': 'NIC Static IP Configuration', 'Result': ('PASS' if primary_dhcp == 'manual' else 'FAIL'),


### PR DESCRIPTION
…for interfaces with hyphens (e.g., br-ext → ansible_br_ext)

We have identified the root cause of the issue.

The failure occurs due to how Ansible stores network interface facts. Interfaces
containing hyphens (e.g., br-ext, bond-mgmt) are internally represented with
underscores in ansible_facts (e.g., ansible_br_ext). The existing logic attempted
to access these facts using the original interface names, resulting in undefined
variable errors during preflight checks.

We have implemented a fix to normalize interface names before accessing
ansible_facts and validated the changes in our setup.

Tracker: (https://tracker.ceph.com/issues/75549)

