### PR TITLE
fix module_utils import for galaxy collection

### DIFF
--- a/plugins/modules/ceph_config.py
+++ b/plugins/modules/ceph_config.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule  # type: ignore
 try:
-    from ansible.module_utils.ceph_common import exit_module, build_base_cmd_shell, fatal  # type: ignore
+    from ansible_collections.ceph.cephadm.plugins.module_utils.ceph_common import exit_module, build_base_cmd_shell, fatal  # type: ignore
 except ImportError:
     from module_utils.ceph_common import exit_module, build_base_cmd_shell, fatal  # type: ignore
 

--- a/plugins/modules/ceph_config_key.py
+++ b/plugins/modules/ceph_config_key.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule  # type: ignore
 try:
-    from ansible.module_utils.ceph_common import exit_module, build_base_cmd_shell, fatal  # type: ignore
+    from ansible_collections.ceph.cephadm.plugins.module_utils.ceph_common import exit_module, build_base_cmd_shell, fatal  # type: ignore
 except ImportError:
     from module_utils.ceph_common import exit_module, build_base_cmd_shell, fatal  # type: ignore
 

--- a/plugins/modules/ceph_orch_apply.py
+++ b/plugins/modules/ceph_orch_apply.py
@@ -23,7 +23,7 @@ import yaml
 
 from ansible.module_utils.basic import AnsibleModule  # type: ignore
 try:
-    from ansible.module_utils.ceph_common import exit_module, build_base_cmd_orch  # type: ignore
+    from ansible_collections.ceph.cephadm.plugins.module_utils.ceph_common import exit_module, build_base_cmd_orch  # type: ignore
 except ImportError:
     from module_utils.ceph_common import exit_module, build_base_cmd_orch
 

--- a/plugins/modules/ceph_orch_daemon.py
+++ b/plugins/modules/ceph_orch_daemon.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule  # type: ignore
 try:
-    from ansible.module_utils.ceph_common import retry, exit_module, build_base_cmd_orch, fatal  # type: ignore
+    from ansible_collections.ceph.cephadm.plugins.module_utils.ceph_common import retry, exit_module, build_base_cmd_orch, fatal  # type: ignore
 except ImportError:
     from module_utils.ceph_common import retry, exit_module, build_base_cmd_orch, fatal  # type: ignore
 

--- a/plugins/modules/ceph_orch_host.py
+++ b/plugins/modules/ceph_orch_host.py
@@ -20,7 +20,7 @@ __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule  # type: ignore
 try:
-    from ansible.module_utils.ceph_common import exit_module, build_base_cmd_orch  # type: ignore
+    from ansible_collections.ceph.cephadm.plugins.module_utils.ceph_common import exit_module, build_base_cmd_orch  # type: ignore
 except ImportError:
     from module_utils.ceph_common import exit_module, build_base_cmd_orch
 import datetime

--- a/plugins/modules/cephadm_bootstrap.py
+++ b/plugins/modules/cephadm_bootstrap.py
@@ -21,7 +21,7 @@ __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule  # type: ignore
 try:
-    from ansible.module_utils.ceph_common import exit_module  # type: ignore
+    from ansible_collections.ceph.cephadm.plugins.module_utils.ceph_common import exit_module  # type: ignore
 except ImportError:
     from module_utils.ceph_common import exit_module
 import datetime

--- a/plugins/modules/cephadm_registry_login.py
+++ b/plugins/modules/cephadm_registry_login.py
@@ -20,7 +20,7 @@ __metaclass__ = type
 from ansible.module_utils.basic import AnsibleModule  # type: ignore
 from typing import List, Tuple
 try:
-    from ansible.module_utils.ceph_common import exit_module, build_base_cmd, fatal  # type: ignore
+    from ansible_collections.ceph.cephadm.plugins.module_utils.ceph_common import exit_module, build_base_cmd, fatal  # type: ignore
 except ImportError:
     from module_utils.ceph_common import exit_module, build_base_cmd, fatal
 import datetime


### PR DESCRIPTION
It's my understanding of https://docs.ansible.com/projects/ansible/latest/dev_guide/developing_module_utilities.html#naming-and-finding-module-utilities that this is how these should be imported, I can also make it so that it uses a `try ... catch` too in case there are older versions that like it how it is now