### PR TITLE
Fix cephadm-ansible.spec

### DIFF
--- a/cephadm-ansible.spec.in
+++ b/cephadm-ansible.spec.in
@@ -30,7 +30,15 @@ cephadm-ansible is a collection of Ansible playbooks to simplify workflows that 
 %install
 mkdir -p %{buildroot}%{_datarootdir}/cephadm-ansible
 
-for f in ansible.cfg *.yml ceph_defaults library module_utils validate; do
+for f in ansible.cfg *.yml \
+  ceph_defaults \
+  library \
+  module_utils \
+  roles \
+  playbooks \
+  plugins \
+  templates \
+  validate; do
   cp -a $f %{buildroot}%{_datarootdir}/cephadm-ansible
 done
 


### PR DESCRIPTION
Since the conversion to an ansible collection, the rpm spec file does not include the new folders plugins/playbooks/roles