### PR TITLE
cephadm-preflight: fix repo baseurl variable and URL formatting

### DIFF
--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -82,7 +82,12 @@
                   name: ceph_stable
                   description: "{{ 'Ceph Stable repo' if ceph_defaults_ceph_origin == 'community' else 'IBM Ceph repo' }}"
                   rpm_key: "{{ ceph_defaults_ceph_stable_key if ceph_defaults_ceph_origin == 'community' else ceph_defaults_ceph_ibm_key }}"
-                  baseurl: "{{ ceph_community_repo_baseurl if ceph_defaults_ceph_origin == 'community' else ceph_defaults_ceph_ibm_repo_baseurl }}"
+                  baseurl: >-
+                    {{
+                       ceph_defaults_ceph_community_repo_baseurl
+                       if ceph_defaults_ceph_origin == 'community'
+                       else ceph_defaults_ceph_ibm_repo_baseurl
+                    }}
                   paths: "{{ ['noarch', '$basearch'] if ceph_defaults_ceph_origin == 'community' else ['$basearch'] }}"
 
             - name: Configure ceph repository key

--- a/roles/ceph_defaults/defaults/main.yml
+++ b/roles/ceph_defaults/defaults/main.yml
@@ -7,12 +7,12 @@ ceph_defaults_ceph_ibm_version: 9
 ceph_defaults_ceph_mirror: https://download.ceph.com
 ceph_defaults_ceph_stable_key: https://download.ceph.com/keys/release.asc
 ceph_defaults_ceph_community_repo_baseurl: >-
-  "{{ ceph_defaults_ceph_mirror }}/
-  rpm-{{ ceph_defaults_ceph_release }}/el{{ ansible_facts['distribution_major_version'] }}/"
+  {{ ceph_defaults_ceph_mirror }}/rpm-{{ ceph_defaults_ceph_release
+  }}/el{{ ansible_facts['distribution_major_version'] }}/
 ceph_defaults_ceph_ibm_repo_baseurl: >-
-  https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/
-  {{ ceph_defaults_ceph_ibm_version }}/
-  rhel{{ ansible_facts['distribution_major_version'] }}/
+  https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/{{
+  ceph_defaults_ceph_ibm_version }}/rhel{{
+  ansible_facts['distribution_major_version'] }}/
 ceph_defaults_ceph_ibm_key: https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/RPM-GPG-KEY-IBM-CEPH
 ceph_defaults_ceph_release: quincy
 ceph_defaults_upgrade_ceph_packages: false


### PR DESCRIPTION
Use ceph_defaults_ceph_community_repo_baseurl in cephadm-preflight instead of the undefined ceph_community_repo_baseurl.

Also convert community and IBM repo baseurl defaults to single-line strings to avoid whitespace/newline insertion in rendered yum/dnf repo URLs.

Fixes: https://tracker.ceph.com/issues/76514