### PR TITLE
Add  license and callhome flags to cephadm bootstrap

### DIFF
--- a/plugins/modules/cephadm_bootstrap.py
+++ b/plugins/modules/cephadm_bootstrap.py
@@ -281,6 +281,7 @@ def main() -> None:
     )
 
     cephadm_bootstrap_downstream_only = dict(
+        automatically_accept_license=dict(type='bool', required=False),
         call_home_config=dict(type='str', required=False),
         call_home_icn=dict(type='str', required=False),
         ceph_call_home_contact_email=dict(type='str', required=False),
@@ -289,6 +290,7 @@ def main() -> None:
         ceph_call_home_contact_phone=dict(type='str', required=False),
         ceph_call_home_country_code=dict(type='str', required=False),
         deploy_cephadm_agent=dict(type='bool', required=False),
+        disable_ibm_call_home=dict(type='bool', required=False),
         enable_ibm_call_home=dict(type='bool', required=False),
         enable_storage_insights=dict(type='bool', required=False),
         storage_insights_config=dict(type='str', required=False),


### PR DESCRIPTION
Add support for the downstream-only cephadm bootstrap options automatically_accept_license and disable_ibm_call_home.

IBM Ceph 9.9.1+ requires license acceptance during bootstrap, and Call Home can be skipped by passing --disable-ibm-call-home. The cephadm_bootstrap Ansible module previously rejected these options during argument validation before cephadm bootstrap was invoked.

Add both parameters to the downstream bootstrap option list so they are accepted by the module and translated into:

  --automatically-accept-license
  --disable-ibm-call-home

Resolves: IBMCEPH-15709

Testing:

```
❯ ansible-playbook -vvvv \                                                                                                                                                                                      ─╯
  -i ~/ansible-inventory/inventory.ini \
  /tmp/bootstrap-with-registry-details.yaml \
  -e 'image=cp.stg.icr.io/cp/ibm-ceph/ceph-9-rhel9:v9.9.1-18140' \
  -e 'registry_url=cp.stg.icr.io' \
  -e 'registry_username=cp' \
  -e 'registry_password=xxxxx \
  -e 'mon_ip=192.168.122.157' \
  -e 'automatically_accept_license=true' \
  -e 'disable_ibm_call_home=true' \
  -e 'allow_fqdn_hostname=true'

ansible-playbook [core 2.18.12]
  config file = /home/kushaldeb/Github/cephadm-ansible/ansible.cfg
  configured module search path = ['/home/kushaldeb/Github/cephadm-ansible/library', '/home/kushaldeb/Github/cephadm-ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.14/site-packages/ansible
  ansible collection location = /home/kushaldeb/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/bin/ansible-playbook
  python version = 3.14.5 (main, May 11 2026, 00:00:00) [GCC 15.2.1 20260123 (Red Hat 15.2.1-7)] (/usr/bin/python3)
  jinja version = 3.1.6
  libyaml = True
```

```
[WARNING]: Module did not set no_log for dashboard_password_noupdate
changed: [rhel10-builder] => changed=true 
  cmd:
  - cephadm
  - --image
  - cp.stg.icr.io/cp/ibm-ceph/ceph-9-rhel9:v9.9.1-18140
  - bootstrap
  - --allow-fqdn-hostname
  - --mon-ip
  - 192.168.122.157
  - --registry-password
  - VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
  - --registry-url
  - cp.stg.icr.io
  - --registry-username
  - cp
  - --automatically-accept-license
  - --disable-ibm-call-home
  delta: '0:01:02.507934'
  diff:
    after: ''
    before: ''
  end: '2026-06-19 11:42:01.421846'
  invocation:
    module_args:
      allow_fqdn_hostname: true
      allow_mismatched_release: null
      allow_overwrite: false
      apply_spec: null
      automatically_accept_license: true
      call_home_config: null
      call_home_icn: null
      ceph_call_home_contact_email: null
      ceph_call_home_contact_first_name: null
      ceph_call_home_contact_last_name: null
      ceph_call_home_contact_phone: null
      ceph_call_home_country_code: null
      cluster_network: null
      config: null
      dashboard: null
      dashboard_crt: null
      dashboard_key: null
      dashboard_password: null
      dashboard_password_noupdate: null
      dashboard_user: null
      deploy_cephadm_agent: null
      disable_ibm_call_home: true
      docker: false
      enable_ibm_call_home: null
      enable_storage_insights: null
      firewalld: null
      fsid: null
      image: cp.stg.icr.io/cp/ibm-ceph/ceph-9-rhel9:v9.9.1-18140
      initial_dashboard_password: null
      initial_dashboard_user: null
      log_to_file: null
      mgr_id: null
      mon_addrv: null
      mon_id: null
      mon_ip: 192.168.122.157
      monitoring: null
      no_cleanup_on_failure: null
      no_minimize_config: null
      orphan_initial_daemons: null
      output_config: null
      output_dir: null
      output_keyring: null
      output_pub_ssh_key: null
      pull: null
      registry_json: null
      registry_password: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
      registry_url: cp.stg.icr.io
      registry_username: cp
      shared_ceph_folder: null
      single_host_defaults: null
      skip_admin_label: null
      skip_dashboard: false
      skip_firewalld: false
      skip_mon_network: null
      skip_monitoring_stack: false
      skip_ping_check: null
      skip_prepare_host: null
      skip_pull: null
      skip_ssh: null
      ssh_config: null
      ssh_private_key: null
      ssh_public_key: null
      ssh_signed_cert: null
      ssh_user: null
      ssl_dashboard_port: null
      storage_insights_config: null
      storage_insights_tenant_id: null
      with_centralized_logging: null
  rc: 0
  start: '2026-06-19 11:40:58.913912'
  stderr: ''
  stderr_lines: <omitted>
  stdout: |-
    Verifying podman|docker is present...
    Verifying lvm2 is present...
    Verifying time synchronization is in place...
    Unit chronyd.service is enabled and running
    Repeating the final host check...
    podman (/usr/bin/podman) version 5.6.0 is present
    systemctl is present
    lvcreate is present
    Unit chronyd.service is enabled and running
    Host looks OK
    Cluster fsid: a42d6fa6-6ba5-11f1-b118-525400bbf44b
    Verifying IP 192.168.122.157 port 3300 ...
    Verifying IP 192.168.122.157 port 6789 ...
    Mon IP `192.168.122.157` is in CIDR network `192.168.122.0/24`
    Mon IP `192.168.122.157` is in CIDR network `192.168.122.0/24`
    Internal network (--cluster-network) has not been provided, OSD replication will default to the public_network
    Logging into custom registry.
    Pulling container image cp.stg.icr.io/cp/ibm-ceph/ceph-9-rhel9:v9.9.1-18140...
    Ceph version: ceph version 20.2.1-280.el9cp (35f966fe3e9886d95892e94ee817f730213d9dd4) tentacle (stable)
    Extracting ceph user uid/gid from container image...
    Creating initial keys...
    Creating initial monmap...
    Creating mon...
    firewalld ready
    Enabling firewalld service ceph-mon in current zone...
    Waiting for mon to start...
    Waiting for mon...
    mon is available
    Assimilating anything we can from ceph.conf...
    Generating new minimal ceph.conf...
    Restarting the monitor...
    Setting public_network to 192.168.122.0/24 in global config section
    Wrote config to /etc/ceph/ceph.conf
    Wrote keyring to /etc/ceph/ceph.client.admin.keyring
    Creating mgr...
    Verifying port 0.0.0.0:9283 ...
    Verifying port 0.0.0.0:8765 ...
    Verifying port 0.0.0.0:8443 ...
    firewalld ready
    Enabling firewalld service ceph in current zone...
    firewalld ready
    Enabling firewalld port 9283/tcp in current zone...
    Enabling firewalld port 8765/tcp in current zone...
    Enabling firewalld port 8443/tcp in current zone...
    Waiting for mgr to start...
    Waiting for mgr...
    mgr not available, waiting (1/15)...
    mgr not available, waiting (2/15)...
    mgr is available
    Enabling cephadm module...
    Waiting for the mgr to restart...
    Waiting for mgr epoch 4...
    mgr epoch 4 is available
    Waiting for orchestrator module...
    orchestrator module is available
    Setting orchestrator backend to cephadm...
    Generating ssh key...
    Wrote public SSH key to /etc/ceph/ceph.pub
    Adding key to root@localhost authorized_keys...
    Adding host localhost.localdomain...
    Deploying mon service with default placement...
    Deploying mgr service with default placement...
    Deploying crash service with default placement...
    Deploying ceph-exporter service with default placement...
    Deploying prometheus service with default placement...
    Deploying grafana service with default placement...
    Deploying node-exporter service with default placement...
    Deploying alertmanager service with default placement...
    Enabling the dashboard module...
    Waiting for the mgr to restart...
    Waiting for mgr epoch 7...
    mgr epoch 7 is available
    Waiting for orchestrator module...
    orchestrator module is available
    Using certmgr to generate dashboard self-signed certificate...
    Creating initial admin user...
    Fetching dashboard port number...
    firewalld ready
    Ceph Dashboard is now available at:
  
                 URL: https://localhost.localdomain:8443/
                User: admin
            Password: o2yuehs6bz
  
    Enabling client.admin keyring and conf on hosts with "admin" label
    Saving cluster configuration to /var/lib/ceph/a42d6fa6-6ba5-11f1-b118-525400bbf44b/config directory
    Skipping call home integration. --disable-ibm-call-home provided
    You can access the Ceph CLI as following in case of multi-cluster or non-default config:
  
            sudo /usr/local/sbin/cephadm shell --fsid a42d6fa6-6ba5-11f1-b118-525400bbf44b -c /etc/ceph/ceph.conf -k /etc/ceph/ceph.client.admin.keyring
  
    Or, if you are only running a single cluster on this host:
  
            sudo /usr/local/sbin/cephadm shell
  
    Please consider enabling telemetry to help improve Ceph:
  
            ceph telemetry on
  
    For more information see:
  
            https://docs.ceph.com/en/latest/mgr/telemetry/
  
    Bootstrap complete.
    Enabling the logrotate.timer service to perform daily log rotation.
  stdout_lines: <omitted>

PLAY RECAP ********************************************************************************************************************************************************************************************************
rhel10-builder             : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

```
