### PR TITLE
cephadm-preflight: add cephadm_preflight_manage_firewall skip option

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,19 @@ Options:
 
 `custom_repo_url`: The url of the repository when `ceph_origin` is 'custom'.
 `custom_repo_gpgkey`: The url of the gpg key corresponding to the repository set in `custom_repo_url` when `ceph_origin` is 'custom'.
+`cephadm_preflight_manage_firewall`: Whether to enable and start firewalld during preflight.\
+**valid values:**
+
+* `true`: Enable and start firewalld on all nodes.
+* `false`: Do not modify firewalld state.
+
+**default**: true
+
+Set to `false` when host firewalls are intentionally disabled and network security is handled externally:
+
+```
+ansible-playbook -i <inventory host file> cephadm-preflight.yml --extra-vars "cephadm_preflight_manage_firewall=false"
+```
 
 # Purge
 

--- a/cephadm-preflight.yml
+++ b/cephadm-preflight.yml
@@ -238,6 +238,7 @@
             enabled: true
 
         - name: Ensure firewalld is enabled and running
+          when: ceph_defaults_preflight_manage_firewall | default(true) | bool
           ansible.builtin.systemd:
             name: firewalld
             state: started

--- a/roles/ceph_defaults/defaults/main.yml
+++ b/roles/ceph_defaults/defaults/main.yml
@@ -16,6 +16,7 @@ ceph_defaults_ceph_ibm_repo_baseurl: >-
 ceph_defaults_ceph_ibm_key: https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/RPM-GPG-KEY-IBM-CEPH
 ceph_defaults_ceph_release: quincy
 ceph_defaults_upgrade_ceph_packages: false
+ceph_defaults_preflight_manage_firewall: true
 ceph_defaults_ceph_pkgs:
   - cephadm
   - ceph-common

--- a/roles/ceph_defaults/tasks/main.yml
+++ b/roles/ceph_defaults/tasks/main.yml
@@ -78,3 +78,8 @@
   ansible.builtin.set_fact:
     ceph_defaults_client_group: "{{ client_group }}"
   when: client_group is defined
+
+- name: Backward compatibility for cephadm_preflight_manage_firewall
+  ansible.builtin.set_fact:
+    ceph_defaults_preflight_manage_firewall: "{{ cephadm_preflight_manage_firewall }}"
+  when: cephadm_preflight_manage_firewall is defined


### PR DESCRIPTION
## Problem

`cephadm-preflight.yml` unconditionally enables and starts `firewalld`
during host preparation. In deployments where host-level firewalls are
intentionally disabled, running preflight during an upgrade can disrupt
inter-node Ceph connectivity.

## Solution

Gate the firewalld task behind `cephadm_preflight_manage_firewall`
(default `true`) so administrators can skip host firewall management:

```bash
ansible-playbook -i <inventory> cephadm-preflight.yml \
  --extra-vars "cephadm_preflight_manage_firewall=false"
```

Implementation details:
- Uses `ceph_defaults_preflight_manage_firewall` internally (repo convention)
- Accepts `cephadm_preflight_manage_firewall` via backward-compatibility alias
- Default `true` preserves existing preflight behavior unless explicitly skipped
- Documented in `README.md`

## Related issues

Fixes: https://tracker.ceph.com/issues/76709

## Note on #371

PR #371 proposes a similar change with `configure_firewalld` defaulting to
`false` (opt-in). This PR defaults to `true` (opt-out) to avoid changing
behavior for deployments that rely on preflight enabling firewalld. Happy to
align on the default with maintainers during review.

## Test plan

- [x] Stock preflight on nodes with firewalld disabled: task runs, firewalld enabled
- [x] `cephadm_preflight_manage_firewall=false`: task skipped, firewalld unchanged
- [x] `cephadm_preflight_manage_firewall=true`: firewalld enabled (default path)
- [ ] Jenkins `cephadm-ansible PR Pipeline` (needs maintainer `ok to test`)